### PR TITLE
Fix a typo and an error in the web site

### DIFF
--- a/docs/design/BinaryEncoding.md
+++ b/docs/design/BinaryEncoding.md
@@ -461,7 +461,7 @@ Function bodies consist of a sequence of local variable declarations followed by
 | local_count | `varuint32` | number of local entries |
 | locals | `local_entry*` | local variables |
 | code | `byte*` | bytecode of the function |
-| end | `byte` | `0x0f`, indicating the end of the body |
+| end | `byte` | `0x0b`, indicating the end of the body |
 
 #### Local Entry
 

--- a/docs/design/TextFormat.md
+++ b/docs/design/TextFormat.md
@@ -9,7 +9,7 @@ modules.
 
 # Linear bytecode
 
-WebAssembly function bodies encode bytecode instructions which have specified canonical opcode names. A linear presentation of these sequences of instructions allows a direct human-readable order-preserving presentation of the binary format. This format is suitable for opcode by opcode inspection of a WebAssembly program and can readily be related to the [sematics](Semantics.md) of the format. 
+WebAssembly function bodies encode bytecode instructions which have specified canonical opcode names. A linear presentation of these sequences of instructions allows a direct human-readable order-preserving presentation of the binary format. This format is suitable for opcode by opcode inspection of a WebAssembly program and can readily be related to the [semantics](Semantics.md) of the format. 
 
 Here is an example function illustrated in C++, binary, and text (linear
 assembly bytecode):

--- a/docs/docs/binary-encoding/index.html
+++ b/docs/docs/binary-encoding/index.html
@@ -1211,7 +1211,7 @@ count may be greater or less than the actual number of locals.</p>
       <td>end</td>
       <td><code class="highlighter-rouge">byte</code></td>
       <td>
-<code class="highlighter-rouge">0x0f</code>, indicating the end of the body</td>
+<code class="highlighter-rouge">0x0b</code>, indicating the end of the body</td>
     </tr>
   </tbody>
 </table>

--- a/docs/docs/text-format/index.html
+++ b/docs/docs/text-format/index.html
@@ -52,7 +52,7 @@ modules.</p>
 
 <h1 id="linear-bytecode">Linear bytecode</h1>
 
-<p>WebAssembly function bodies encode bytecode instructions which have specified canonical opcode names. A linear presentation of these sequences of instructions allows a direct human-readable order-preserving presentation of the binary format. This format is suitable for opcode by opcode inspection of a WebAssembly program and can readily be related to the <a href="../semantics/">sematics</a> of the format.</p>
+<p>WebAssembly function bodies encode bytecode instructions which have specified canonical opcode names. A linear presentation of these sequences of instructions allows a direct human-readable order-preserving presentation of the binary format. This format is suitable for opcode by opcode inspection of a WebAssembly program and can readily be related to the <a href="../semantics/">semantics</a> of the format.</p>
 
 <p>Here is an example function illustrated in C++, binary, and text (linear
 assembly bytecode):</p>


### PR DESCRIPTION
Fixed a typo (sematics instead of semantics)

Fixed what I believe is an error with the encoding for 'end' (it's listed as 0xb, not 0xf in the encoding table)