### PR TITLE
Add Node talk to community events page

### DIFF
--- a/docs/design/Events.md
+++ b/docs/design/Events.md
@@ -11,6 +11,7 @@
 | September 14th 2016 | WebAssembly: birth of a virtual ISA | | [video](https://www.youtube.com/watch?v=vmzz17JGPHI) | Ben Smith |
 | September 21st 2016 | C++ on the Web: Let's have some serious fun | | [video](https://www.youtube.com/watch?v=jXMtQ2fTl4c) | Dan Gohman |
 | September 22nd 2016 | WebAssembly: high speed at low cost for everyone | [paper](http://www.mlworkshop.org/2016-1.pdf) | | Andreas Rossberg |
+| November 7th 2016 | Empire Node: How Webassembly Will Change the Way You Write Javascript | | [video](https://www.youtube.com/watch?v=kq2HBddiyh0) | Seth Samuel |
 | November 12th 2016 | Chrome Dev Summit Advanced JS performance with V8 and WebAssembly | | [video](https://www.youtube.com/watch?v=PvZdTZ1Nl5o) | Seth Thompson |
 
 


### PR DESCRIPTION
I'm not sure whether the scope of this page is limited to talks given by people working on the standard. If it is not, this is a helpful talk that demonstrates using WASM with Node. The Node workflow is still clunky, but I think adventuresome developers might want to tinker with it, and this is the only demo of it I've seen.