### PR TITLE
Update getting started developer's guide.

### DIFF
--- a/getting-started/developers-guide.md
+++ b/getting-started/developers-guide.md
@@ -4,30 +4,39 @@ layout: getting-started
 
 # Developer's Guide
 
-This page aims to provide complete, working step-by-step instructions to compile a simple program directly to WebAssembly.
+This page provides step-by-step instructions to compile a simple program directly to WebAssembly.
 
-The instructions on this page are applicable to Linux and Mac OS X systems. Similar instructions for Windows systems are forthcoming.
+### Prerequisites
+To compile to WebAssembly, we will at the moment need to compile LLVM from source. The following tools are needed as a prerequisite:
 
-### Install the correct version of emscripten
-To compile to WebAssembly, we need the incoming branch of emscripten. We can install this through the [emscripten SDK](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html);
-  however, we need to switch the branch the SDK downloads and installs from.
+- Git. On Linux and OS X this is likely already present. On Windows download the [Git for Windows](https://git-scm.com/) installer.
+- CMake. On Linux and OS X, one can use package managers like `apt-get` or `brew`, on Windows download [CMake installer](https://cmake.org/download/).
+- Host system compiler. On Linux, [install GCC](http://askubuntu.com/questions/154402/install-gcc-on-ubuntu-12-04-lts). On OS X, [install Xcode](https://itunes.apple.com/us/app/xcode/id497799835). On Windows, install [Visual Studio 2015 Community with Update 3](https://www.visualstudio.com/downloads/) or newer.
+- Python 2.7.x. On Linux and OS X, this is most likely provided out of the box. See [here](https://wiki.python.org/moin/BeginnersGuide/Download) for instructions.
 
-    $ curl https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-portable.tar.gz \
-    -o emsdk-portable.tar.gz
-    $ gunzip emsdk-portable.tar.gz
-    $ tar -xf emsdk-portable.tar
-    $ cd emsdk_portable
-    $ ./emsdk update
-    $ ./emsdk install clang-incoming-64bit emscripten-incoming-64bit sdk-incoming-64bit
-    $ ./emsdk activate clang-incoming-64bit emscripten-incoming-64bit sdk-incoming-64bit
+After installing, make sure that `git`, `cmake` and `python` are accessible in PATH.
+
+### Compile Emscripten from Source
+Building Emscripten from source is automated via the Emscripten SDK. The required steps are as follows.
+
+    $ git clone https://github.com/juj/emsdk.git
+    $ cd emsdk
+    $ ./emsdk install sdk-incoming-64bit binaryen-master-64bit
+    $ ./emsdk activate sdk-incoming-64bit binaryen-master-64bit
+
+After these steps, the installation is complete. To enter an Emscripten compiler environment in the current command line prompt, type
+
     $ source ./emsdk_env.sh
-    $ cd ..
+
+This command adds relevant environment variables and directory entries to PATH to set up the current terminal for easy access to the compiler tools.
+
+On Windows, replace `./emsdk` with just `emsdk`, and `source ./emsdk_env.sh` with `emsdk_env` above.
 
 ### Compile and run a simple program
 We now have a full toolchain we can use to compile a simple program to WebAssembly. There are a few remaining caveats, however:
 
-- We have to pass the flag `-s WASM=1` to `emcc` (otherwise by default `emcc` will emit asm.js).
-- If we want emscripten to generate an HTML page that runs our program, in addition to the wasm binary and JavaScript wrapper, we have to specify an output filename with a `.html` extension.
+- We have to pass the linker flag `-s WASM=1` to `emcc` (otherwise by default `emcc` will emit asm.js).
+- If we want Emscripten to generate an HTML page that runs our program, in addition to the wasm binary and JavaScript wrapper, we have to specify an output filename with a `.html` extension.
 - Finally, to actually run the program, we cannot simply open the HTML file in a web browser because cross-origin requests are not supported for the `file` protocol scheme. We have to actually serve the output files over HTTP.
 
 The commands below will create a simple "hello world" program and compile it. The compilation step is highlighted in bold.
@@ -42,8 +51,8 @@ $ echo '}' &gt;&gt; hello.c
 $ <b>emcc hello.c -s WASM=1 -o hello.html</b>
 </pre>
 
-To serve the compiled files over HTTP, we can use the HTTP server built in to Python:
+To serve the compiled files over HTTP, we can use the `emrun` web server provided with the Emscripten SDK:
 
-    $ python -m SimpleHTTPServer 8080 > /dev/null 2>&1 &;
+    $ emrun --no_browser --port 8080 .
 
-Once the HTTP server is running, you can <a href="http://localhost:8080/hello.html" target="_blank">open it in your browser</a>. If you see "Hello, world!" printed to the emscripten console, then congratulations! You've successfully compiled to WebAssembly!
+Once the HTTP server is running, you can <a href="http://localhost:8080/hello.html" target="_blank">open it in your browser</a>. If you see "Hello, world!" printed to the Emscripten console, then congratulations! You've successfully compiled to WebAssembly!


### PR DESCRIPTION
Improve getting started instructions to refer to the appropriate steps for building latest Emscripten from source. Also use `emrun` instead of python web server, because `emrun` knows to provide proper HTTP response headers to the served files, which SimpleHTTPServer is not aware of. Add Windows instructions as well, and a section on prerequisites.

Once precompiled Emscripten packages are available which don't need building from source, the getting started docs can be rewritten to not require git, CMake or Visual Studio/gcc/Xcode.