### PR TITLE
Changed to 'emsdk_env.bat' from 'emsdk_env'

### DIFF
--- a/docs/getting-started/developers-guide/index.html
+++ b/docs/getting-started/developers-guide/index.html
@@ -74,7 +74,7 @@ $ ./emsdk activate sdk-incoming-64bit binaryen-master-64bit
 
 <p>This command adds relevant environment variables and directory entries to PATH to set up the current terminal for easy access to the compiler tools.</p>
 
-<p>On Windows, replace <code class="highlighter-rouge">./emsdk</code> with just <code class="highlighter-rouge">emsdk</code>, and <code class="highlighter-rouge">source ./emsdk_env.sh</code> with <code class="highlighter-rouge">emsdk_env</code> above.</p>
+<p>On Windows, replace <code class="highlighter-rouge">./emsdk</code> with just <code class="highlighter-rouge">emsdk</code>, and <code class="highlighter-rouge">source ./emsdk_env.sh</code> with <code class="highlighter-rouge">emsdk_env.bat</code> above.</p>
 
 <h3 id="compile-and-run-a-simple-program">Compile and run a simple program</h3>
 <p>We now have a full toolchain we can use to compile a simple program to WebAssembly. There are a few remaining caveats, however:</p>


### PR DESCRIPTION
I believe the windows command to add emsdk to PATH is 'emsdk_env.bat' [link to section in documentation](https://github.com/juj/emsdk#installing-emsdk-directly-from-github)
 