### PR TITLE
Update lock-file to match Gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,10 +56,10 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.1)
-    nokogiri (1.7.1)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     parallel (1.11.1)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
@@ -86,7 +86,7 @@ DEPENDENCIES
   jekyll (~> 3.4)
   jekyll-optional-front-matter (~> 0.1)
   jemoji (~> 0.8)
-  nokogiri (~> 1.7)
+  nokogiri (~> 1.8)
 
 BUNDLED WITH
-   1.14.6
+   1.16.1


### PR DESCRIPTION
ce9efaa7a475d9b4d0228bcb553ee1abad10a487 updated the Gemfile but not the lock-file which caused installs to fail, easy fix 👌 