### PR TITLE
Fix broken link

### DIFF
--- a/docs/getting-started/developers-guide/index.html
+++ b/docs/getting-started/developers-guide/index.html
@@ -21,7 +21,7 @@
       <a class="site-nav-item btn" href="/getting-started/developers-guide/">Getting Started</a>
       
       
-      <a class="site-nav-item btn" href="">Docs</a>
+      <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
       <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>


### PR DESCRIPTION
Associated Issue: #122 

Commit 5a00907 seems to have left the href in the docs link empty (on the developer's guide page). This PR adds it back again.