### PR TITLE
Add Go language to the index page.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,8 +19,8 @@
       <a class="site-nav-item btn" href="/">Overview</a>
       <a class="site-nav-item btn" href="/demo/">Demo</a>
       <a class="site-nav-item btn" href="/getting-started/developers-guide/">Getting Started</a>
-      
-      
+
+
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
       <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
@@ -41,16 +41,16 @@
         &nbsp;&#8203;<a href="/roadmap/">Learn&nbsp;more</a></span>
     </div>
   </section>
-  
+
   <section class="page-section-spacious flush-bottom">
     <div class="container-narrow">
-      <p class="lead">WebAssembly (abbreviated <i>Wasm</i>) is a binary instruction format for a stack-based virtual machine. Wasm is designed as a portable target for compilation of high-level languages like C/C++/Rust, enabling deployment on the web for client and server applications.</p>
+      <p class="lead">WebAssembly (abbreviated <i>Wasm</i>) is a binary instruction format for a stack-based virtual machine. Wasm is designed as a portable target for compilation of high-level languages like C/C++/Rust/Go, enabling deployment on the web for client and server applications.</p>
     </div>
   </section>
-  
+
 
 <section>
-  <div class="container-narrow">  
+  <div class="container-narrow">
   <div class="flash flash-warn">
   Developer reference documentation for Wasm can be found on <a href="https://developer.mozilla.org/en-US/docs/WebAssembly">MDN's WebAssembly pages</a>.
   The open standards for WebAssembly are developed in a <a href="https://www.w3.org/community/webassembly/">W3C Community Group</a> (that includes representatives from all major browsers) as well as a <a href="https://www.w3.org/wasm/">W3C Working Group</a>.

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-lead: WebAssembly (abbreviated <i>Wasm</i>) is a binary instruction format for a stack-based virtual machine. Wasm is designed as a portable target for compilation of high-level languages like C/C++/Rust, enabling deployment on the web for client and server applications.
+lead: WebAssembly (abbreviated <i>Wasm</i>) is a binary instruction format for a stack-based virtual machine. Wasm is designed as a portable target for compilation of high-level languages like C/C++/Rust/Go, enabling deployment on the web for client and server applications.
 ---
 <div class="flash flash-warn">
   Developer reference documentation for Wasm can be found on <a href="https://developer.mozilla.org/en-US/docs/WebAssembly">MDN's WebAssembly pages</a>.


### PR DESCRIPTION
The [**Go team**](https://github.com/golang/go/wiki/WebAssembly) has made additional changes to the compiler for compiling Go programs to wasm. We should add this language to the main page.