### PR TITLE
Link to official LLVM repo instead

### DIFF
--- a/docs/design/TextFormat.md
+++ b/docs/design/TextFormat.md
@@ -30,7 +30,7 @@ The following tools currently understand this format:
   [specification interpreter]: https://github.com/WebAssembly/spec/tree/master/interpreter/
   [wabt]: https://github.com/WebAssembly/wabt
   [binaryen]: https://github.com/WebAssembly/binaryen
-  [LLVM backend]: https://github.com/llvm-mirror/llvm/tree/master/test/CodeGen/WebAssembly
+  [LLVM backend]: https://github.com/llvm/llvm-project/tree/master/test/CodeGen/WebAssembly
   [WAVM backend]: https://github.com/AndrewScheidecker/WAVM/tree/master/Test
 
 The recommended file extension for WebAssembly code in textual format is `.wat`.

--- a/docs/docs/text-format/index.html
+++ b/docs/docs/text-format/index.html
@@ -69,7 +69,7 @@ Examples can be found in the WebAssembly <a href="https://github.com/WebAssembly
   <li><a href="https://github.com/WebAssembly/spec/tree/master/interpreter/">specification interpreter</a> consumes an s-expression syntax.</li>
   <li><a href="https://github.com/WebAssembly/wabt">wabt</a> consumes compatible s-expressions.</li>
   <li><a href="https://github.com/WebAssembly/binaryen">binaryen</a> can consume compatible s-expressions.</li>
-  <li><a href="https://github.com/llvm-mirror/llvm/tree/master/test/CodeGen/WebAssembly">LLVM backend</a> (the <code class="highlighter-rouge">CHECK:</code> parts of these tests) emits compatible s-expressions.</li>
+  <li><a href="https://github.com/llvm/llvm-project/tree/master/test/CodeGen/WebAssembly">LLVM backend</a> (the <code class="highlighter-rouge">CHECK:</code> parts of these tests) emits compatible s-expressions.</li>
   <li>
     <p><a href="https://github.com/AndrewScheidecker/WAVM/tree/master/Test">WAVM backend</a> consumes compatible s-expressions.</p>
 

--- a/docs/roadmap/index.html
+++ b/docs/roadmap/index.html
@@ -68,7 +68,7 @@ and <a href="https://github.com/WebAssembly/spec/tree/master/interpreter">spec i
 into a single unified specification in the <a href="https://github.com/WebAssembly/spec">spec</a>
 repo</li>
   <li>propose a new charter for a W3C WebAssembly Working Group</li>
-  <li>graduate the <a href="https://github.com/llvm-mirror/llvm/tree/master/test/CodeGen/WebAssembly">WebAssembly LLVM backend</a> from experimental to stable (and update Emscripten)</li>
+  <li>graduate the <a href="https://github.com/llvm/llvm-project/tree/master/test/CodeGen/WebAssembly">WebAssembly LLVM backend</a> from experimental to stable (and update Emscripten)</li>
   <li>prototype additional WebAssembly integration into browser developer tools</li>
   <li>Start work on <a href="/docs/future-features/">post-MVP features</a></li>
 </ul>

--- a/roadmap.md
+++ b/roadmap.md
@@ -23,7 +23,7 @@ The WebAssembly community group and contributors plan to:
   into a single unified specification in the [spec](https://github.com/WebAssembly/spec)
   repo
 * propose a new charter for a W3C WebAssembly Working Group
-* graduate the [WebAssembly LLVM backend](https://github.com/llvm-mirror/llvm/tree/master/test/CodeGen/WebAssembly) from experimental to stable (and update Emscripten)
+* graduate the [WebAssembly LLVM backend](https://github.com/llvm/llvm-project/tree/master/test/CodeGen/WebAssembly) from experimental to stable (and update Emscripten)
 * prototype additional WebAssembly integration into browser developer tools
 * Start work on [post-MVP features](/docs/future-features/)
 


### PR DESCRIPTION
LLVM has an official repository on Github now. Link to it instead of the mirror
repo.

Related: https://github.com/WebAssembly/design/pull/1269