### PR TITLE
Remove emcc WASM=1 flag in developers' guide, as it has not been needed for a while

### DIFF
--- a/docs/getting-started/developers-guide/index.html
+++ b/docs/getting-started/developers-guide/index.html
@@ -132,7 +132,6 @@ $ ./emsdk activate --build=Release sdk-incoming-64bit binaryen-master-64bit
 <p>We now have a full toolchain we can use to compile a simple program to WebAssembly. There are a few remaining caveats, however:</p>
 
 <ul>
-  <li>We have to pass the linker flag <code class="highlighter-rouge">-s WASM=1</code> to <code class="highlighter-rouge">emcc</code> (otherwise by default <code class="highlighter-rouge">emcc</code> will emit asm.js).</li>
   <li>If we want Emscripten to generate an HTML page that runs our program, in addition to the Wasm binary and JavaScript wrapper, we have to specify an output filename with a <code class="highlighter-rouge">.html</code> extension.</li>
   <li>Finally, to actually run the program, we cannot simply open the HTML file in a web browser because cross-origin requests are not supported for the <code class="highlighter-rouge">file</code> protocol scheme. We have to actually serve the output files over HTTP.</li>
 </ul>
@@ -148,7 +147,7 @@ int main(int argc, char ** argv) {
   printf("Hello, world!\n");
 }
 EOF
-$ <b>emcc hello.c -s WASM=1 -o hello.html</b>
+$ <b>emcc hello.c -o hello.html</b>
 </pre>
 
 <p>To serve the compiled files over HTTP, we can use the <code class="highlighter-rouge">emrun</code> web server provided with the Emscripten SDK:</p>

--- a/getting-started/developers-guide.md
+++ b/getting-started/developers-guide.md
@@ -72,7 +72,6 @@ This command adds relevant environment variables and directory entries to PATH t
 ## Compile and run a simple program
 We now have a full toolchain we can use to compile a simple program to WebAssembly. There are a few remaining caveats, however:
 
-- We have to pass the linker flag `-s WASM=1` to `emcc` (otherwise by default `emcc` will emit asm.js).
 - If we want Emscripten to generate an HTML page that runs our program, in addition to the Wasm binary and JavaScript wrapper, we have to specify an output filename with a `.html` extension.
 - Finally, to actually run the program, we cannot simply open the HTML file in a web browser because cross-origin requests are not supported for the `file` protocol scheme. We have to actually serve the output files over HTTP.
 
@@ -87,7 +86,7 @@ int main(int argc, char ** argv) {
   printf("Hello, world!\n");
 }
 EOF
-$ <b>emcc hello.c -s WASM=1 -o hello.html</b>
+$ <b>emcc hello.c -o hello.html</b>
 </pre>
 
 To serve the compiled files over HTTP, we can use the `emrun` web server provided with the Emscripten SDK:


### PR DESCRIPTION
The emcc default is wasm anyhow.

CI errors on something unrelated about Ruby - any ideas?
```ruby
$ bundle install --jobs=3 --retry=3 --deployment
/home/travis/.rvm/rubies/ruby-2.3.8/lib/ruby/site_ruby/2.3.0/rubygems.rb:289:in `find_spec_for_exe': can't find gem bundler (>= 0.a) with executable bundle (Gem::GemNotFoundException)
```
