### PR TITLE
Mark docs folder as autogenerated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/docs/** linguist-generated=true


### PR DESCRIPTION

This should help with reviews by collapsing any changes in `docs` by default.