### PR TITLE
Add Specifications page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -21,7 +21,7 @@
       {% assign sorted = site.pages | sort:"weight"  %}
       {% assign first_doc = sorted | where:"type","doc" | first %}
       <a class="site-nav-item btn" href="{{ first_doc.url }}">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/community/code-of-conduct/index.html
+++ b/docs/community/code-of-conduct/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/community/contributing/index.html
+++ b/docs/community/contributing/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/community/events/index.html
+++ b/docs/community/events/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/community/feedback/index.html
+++ b/docs/community/feedback/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/binary-encoding/index.html
+++ b/docs/docs/binary-encoding/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/c-and-c++/index.html
+++ b/docs/docs/c-and-c++/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/dynamic-linking/index.html
+++ b/docs/docs/dynamic-linking/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/faq/index.html
+++ b/docs/docs/faq/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/feature-test/index.html
+++ b/docs/docs/feature-test/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/future-features/index.html
+++ b/docs/docs/future-features/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/high-level-goals/index.html
+++ b/docs/docs/high-level-goals/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/jit-library/index.html
+++ b/docs/docs/jit-library/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/js/index.html
+++ b/docs/docs/js/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/modules/index.html
+++ b/docs/docs/modules/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/mvp/index.html
+++ b/docs/docs/mvp/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/non-web/index.html
+++ b/docs/docs/non-web/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/nondeterminism/index.html
+++ b/docs/docs/nondeterminism/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/portability/index.html
+++ b/docs/docs/portability/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/rationale/index.html
+++ b/docs/docs/rationale/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/security/index.html
+++ b/docs/docs/security/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/semantics/index.html
+++ b/docs/docs/semantics/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/text-format/index.html
+++ b/docs/docs/text-format/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/tooling/index.html
+++ b/docs/docs/tooling/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/use-cases/index.html
+++ b/docs/docs/use-cases/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/docs/web/index.html
+++ b/docs/docs/web/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/getting-started/advanced-tools/index.html
+++ b/docs/getting-started/advanced-tools/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/getting-started/developers-guide/index.html
+++ b/docs/getting-started/developers-guide/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/getting-started/js-api/index.html
+++ b/docs/getting-started/js-api/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/roadmap/index.html
+++ b/docs/roadmap/index.html
@@ -21,7 +21,7 @@
       
       
       <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
-      <a class="site-nav-item btn" href="https://webassembly.github.io/spec/">Spec</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/community/feedback/">Community</a>
       <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>

--- a/docs/specs/index.html
+++ b/docs/specs/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>Specifications - WebAssembly</title>
+  <link rel="stylesheet" type="text/css" href="/css/custom.css">
+  <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+</head>
+
+
+<body>
+  <header class="page-section">
+    <div class="container-narrow">
+    <div class="site-logo">
+    </div>
+    <nav class="site-nav">
+      <a class="site-nav-item btn" href="/">Overview</a>
+      <a class="site-nav-item btn" href="/getting-started/developers-guide/">Getting Started</a>
+      
+      
+      <a class="site-nav-item btn" href="/docs/high-level-goals/">Docs</a>
+      <a class="site-nav-item btn" href="/specs">Specs</a>
+      <a class="site-nav-item btn" href="/community/feedback/">Community</a>
+      <a class="site-nav-item btn" href="/roadmap/">Roadmap</a>
+      <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>
+    </nav>
+    </div>
+  </header>
+  <section class="banner-update">
+    <div class="container-narrow">
+      <div class="banner-update-icon"></div>
+      <span class="banner-update-date"></span>
+      <span>WebAssembly 1.0 has shipped in 4 major browser engines.
+        &nbsp;<img width="48px" src="/images/firefox.svg"/>
+        &nbsp;<img width="48px" src="/images/chrome.svg"/>
+        &nbsp;<img width="48px" srcset="/images/safari_48x48.png, /images/safari_96x96.png 2x, /images/safari_144x144.png 3x" src="/images/safari_48x48.png"/>
+        &nbsp;<img width="48px" src="/images/edge.svg"/>
+        &nbsp;&#8203;<a href="/roadmap/">Learn&nbsp;more</a></span>
+    </div>
+  </section>
+  
+
+<section>
+  <div class="container-narrow">  
+  <h1 id="specifications">Specifications</h1>
+
+<ul>
+  <li><a href="https://github.com/WebAssembly/design">Design documents</a>: documents describing the design, goals and high-level overview of WebAssembly.</li>
+  <li><a href="https://webassembly.github.io/spec/core/">Core specification</a>: defines the semantics of WebAssembly modules independent from a concrete embedding. The WebAssembly core is specified in a single document.</li>
+  <li>Embedding interfaces:
+    <ul>
+      <li><a href="https://webassembly.github.io/spec/js-api/index.html">JavaScript API</a>: defines JavaScript classes and objects for accessing WebAssembly from within JavaScript, including methods for validation, compilation, instantiation, and classes for representing and manipulating imports and exports as JavaScript objects.</li>
+      <li><a href="https://webassembly.github.io/spec/web-api/index.html">Web API</a>: defines extensions to the JavaScript API made available specifically in web browsers, in particular, an interface for streaming compilation and instantiation from origin-bound <code class="highlighter-rouge">Response</code> types.</li>
+      <li><a href="https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/docs.md">WASI API</a>: defines a modular system interface to run WebAssembly outside the web, providing access to things like files, network connections, clocks, and random numbers.</li>
+    </ul>
+  </li>
+  <li><a href="https://github.com/WebAssembly/tool-conventions">Tool conventions</a>: repository describing non-standard conventions useful for coordinating interoperability between tools working with WebAssembly. This includes conventions for linking schemes, debugging information, language ABIs and more.</li>
+</ul>
+
+  </div>
+</section>
+</body>
+</html>
+

--- a/docs/specs/index.html
+++ b/docs/specs/index.html
@@ -47,7 +47,6 @@
   <h1 id="specifications">Specifications</h1>
 
 <ul>
-  <li><a href="https://github.com/WebAssembly/design">Design documents</a>: documents describing the design, goals and high-level overview of WebAssembly.</li>
   <li><a href="https://webassembly.github.io/spec/core/">Core specification</a>: defines the semantics of WebAssembly modules independent from a concrete embedding. The WebAssembly core is specified in a single document.</li>
   <li>Embedding interfaces:
     <ul>
@@ -57,6 +56,7 @@
     </ul>
   </li>
   <li><a href="https://github.com/WebAssembly/tool-conventions">Tool conventions</a>: repository describing non-standard conventions useful for coordinating interoperability between tools working with WebAssembly. This includes conventions for linking schemes, debugging information, language ABIs and more.</li>
+  <li><a href="https://github.com/WebAssembly/design">Original design documents</a>: documents describing the design, goals and high-level overview of WebAssembly. Some of these documents are outdated by now.</li>
 </ul>
 
   </div>

--- a/specs.md
+++ b/specs.md
@@ -3,7 +3,7 @@ layout: default
 ---
 # Specifications
 
-- [Design documents](https://github.com/WebAssembly/design): documents describing the design, goals and high-level overview of WebAssembly.
+- [Original design documents](https://github.com/WebAssembly/design): documents describing the design, goals and high-level overview of WebAssembly. Some of these documents are outdated by now.
 - [Core specification](https://webassembly.github.io/spec/core/): defines the semantics of WebAssembly modules independent from a concrete embedding. The WebAssembly core is specified in a single document.
 - Embedding interfaces:
   - [JavaScript API](https://webassembly.github.io/spec/js-api/index.html): defines JavaScript classes and objects for accessing WebAssembly from within JavaScript, including methods for validation, compilation, instantiation, and classes for representing and manipulating imports and exports as JavaScript objects.

--- a/specs.md
+++ b/specs.md
@@ -3,10 +3,10 @@ layout: default
 ---
 # Specifications
 
-- [Original design documents](https://github.com/WebAssembly/design): documents describing the design, goals and high-level overview of WebAssembly. Some of these documents are outdated by now.
 - [Core specification](https://webassembly.github.io/spec/core/): defines the semantics of WebAssembly modules independent from a concrete embedding. The WebAssembly core is specified in a single document.
 - Embedding interfaces:
   - [JavaScript API](https://webassembly.github.io/spec/js-api/index.html): defines JavaScript classes and objects for accessing WebAssembly from within JavaScript, including methods for validation, compilation, instantiation, and classes for representing and manipulating imports and exports as JavaScript objects.
   - [Web API](https://webassembly.github.io/spec/web-api/index.html): defines extensions to the JavaScript API made available specifically in web browsers, in particular, an interface for streaming compilation and instantiation from origin-bound `Response` types.
   - [WASI API](https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/docs.md): defines a modular system interface to run WebAssembly outside the web, providing access to things like files, network connections, clocks, and random numbers.
 - [Tool conventions](https://github.com/WebAssembly/tool-conventions): repository describing non-standard conventions useful for coordinating interoperability between tools working with WebAssembly. This includes conventions for linking schemes, debugging information, language ABIs and more.
+- [Original design documents](https://github.com/WebAssembly/design): documents describing the design, goals and high-level overview of WebAssembly. Some of these documents are outdated by now.

--- a/specs.md
+++ b/specs.md
@@ -1,0 +1,12 @@
+---
+layout: default
+---
+# Specifications
+
+- [Design documents](https://github.com/WebAssembly/design): documents describing the design, goals and high-level overview of WebAssembly.
+- [Core specification](https://webassembly.github.io/spec/core/): defines the semantics of WebAssembly modules independent from a concrete embedding. The WebAssembly core is specified in a single document.
+- Embedding interfaces:
+  - [JavaScript API](https://webassembly.github.io/spec/js-api/index.html): defines JavaScript classes and objects for accessing WebAssembly from within JavaScript, including methods for validation, compilation, instantiation, and classes for representing and manipulating imports and exports as JavaScript objects.
+  - [Web API](https://webassembly.github.io/spec/web-api/index.html): defines extensions to the JavaScript API made available specifically in web browsers, in particular, an interface for streaming compilation and instantiation from origin-bound `Response` types.
+  - [WASI API](https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/docs.md): defines a modular system interface to run WebAssembly outside the web, providing access to things like files, network connections, clocks, and random numbers.
+- [Tool conventions](https://github.com/WebAssembly/tool-conventions): repository describing non-standard conventions useful for coordinating interoperability between tools working with WebAssembly. This includes conventions for linking schemes, debugging information, language ABIs and more.


### PR DESCRIPTION
*👋🏻 As some of you know, I've recently taken over work of updating the website to include more relevant content for new developers in this new age. This is one of the first in a series of small PRs towards that goal.*

Instead of linking out to an unstyled https://webassembly.github.io/spec/ page only, provide a list of links to various specs related to WebAssembly in our own UI.