### PR TITLE
Group features by status

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -13,6 +13,21 @@ After the initial release, WebAssembly has been gaining new features through the
 <script src="https://unpkg.com/wasm-feature-detect/dist/umd/index.js"></script>
 <script>
   (async () => {
+    function partitionArray(arr, condition) {
+      let matched = [];
+      let unmatched = [];
+
+      for (let item of arr) {
+        if (condition(item)) {
+          matched.push(item);
+        } else {
+          unmatched.push(item);
+        }
+      }
+
+      return { matched, unmatched };
+    }
+
     let { features, browsers } = await fetch('/features.json').then(res => res.json());
     let table = document.getElementById('feature-support');
 
@@ -44,32 +59,51 @@ After the initial release, WebAssembly has been gaining new features through the
       tBody
     );
 
-    for (let [name, { description, url, phase }] of Object.entries(features)) {
-      let supportHTML = h('td');
-      wasmFeatureDetect[name]()
-        .then(
-          supported => (supported ? '✔️' : '❌'),
-          err => {
-            supportHTML.style.backgroundColor = '#ffcdd2';
-            return err.message;
-          }
-        )
-        .then(textContent => {
-          supportHTML.textContent = textContent;
-        });
+    let featureGroups = partitionArray(
+      Object.entries(features).map(([name, feature]) => Object.assign(feature, { name })),
+      feature => feature.phase >= 4
+    );
+
+    featureGroups = [
+      { name: 'Standardized features', features: featureGroups.matched },
+      { name: 'In-progress proposals', features: featureGroups.unmatched },
+    ];
+
+    const columnCount = 2 + Object.keys(browsers).length;
+
+    for (let { name, features } of featureGroups) {
       tBody.append(
         h('tr', {}, [
-          h('th', {}, [h('a', { href: url }, [description])]),
-          supportHTML,
-          ...Object.values(browsers).map(({ features }) => {
-            let support = features[name];
-            if (typeof support === 'string') {
-              return h('td', { title: support, tabIndex: 0 }, ['⏳']);
-            }
-            return h('td', {}, [support ? '✔️' : '❌']);
-          })
+          h('th', { colSpan: columnCount }, [name])
         ])
       );
+      for (let { name, description, url, phase } of features) {
+        let supportHTML = h('td');
+        wasmFeatureDetect[name]()
+          .then(
+            supported => (supported ? '✔️' : '❌'),
+            err => {
+              supportHTML.style.backgroundColor = '#ffcdd2';
+              return err.message;
+            }
+          )
+          .then(textContent => {
+            supportHTML.textContent = textContent;
+          });
+        tBody.append(
+          h('tr', {}, [
+            h('th', {}, [h('a', { href: url }, [description])]),
+            supportHTML,
+            ...Object.values(browsers).map(({ features }) => {
+              let support = features[name];
+              if (typeof support === 'string') {
+                return h('td', { title: support, tabIndex: 0 }, ['⏳']);
+              }
+              return h('td', {}, [support ? '✔️' : '❌']);
+            })
+          ])
+        );
+      }
     }
   })();
 </script>


### PR DESCRIPTION
This is the first usage of `phase` field.

Note that precise value doesn't matter (which decreases the pressure put on us in keeping those in sync), but "phase 4" vs "the rest" seems like a useful split for developers.

## Before
![image](https://user-images.githubusercontent.com/557590/85594353-c30faa00-b63f-11ea-81e2-a337b31a393f.png)

## After
![image](https://user-images.githubusercontent.com/557590/85594384-cc007b80-b63f-11ea-8eb3-48e47dbb6d78.png)
