### PR TITLE
Firefox 78 updates

### DIFF
--- a/features.json
+++ b/features.json
@@ -76,16 +76,16 @@
 		"Firefox": {
 			"url": "https://www.mozilla.org/firefox/",
 			"logo": "/images/firefox.svg",
-			"version": "77",
+			"version": "78",
 			"features": {
-				"bigInt": "Beta 78",
-				"bulkMemory": "javascript.options.shared_memory",
-				"multiValue": "Beta 78",
+				"bigInt": true,
+				"bulkMemory": true,
+				"multiValue": true,
 				"mutableGlobals": true,
 				"referenceTypes": "Nightly",
 				"saturatedFloatToInt": true,
 				"signExtensions": true,
-				"simd": "Nightly, x86 and x86-64 only",
+				"simd": "Beta 79, x86 and x86-64 only",
 				"threads": "Nightly"
 			}
 		},


### PR DESCRIPTION
@lars-t-hansen [said](https://github.com/WebAssembly/website/pull/174#issuecomment-649455607) that bulkmem and multi-value will land in FF79, but I see those flags enabled by default in FF 78 stable 🤔