### PR TITLE
Enable COOP+COEP on the feature test page

### DIFF
--- a/features.json
+++ b/features.json
@@ -86,7 +86,7 @@
 				"saturatedFloatToInt": true,
 				"signExtensions": true,
 				"simd": "Beta 79, x86 and x86-64 only",
-				"threads": "Nightly"
+				"threads": true
 			}
 		},
 		"Safari": {

--- a/features.json
+++ b/features.json
@@ -86,7 +86,7 @@
 				"saturatedFloatToInt": true,
 				"signExtensions": true,
 				"simd": "Beta 79, x86 and x86-64 only",
-				"threads": true
+				"threads": "Beta 79"
 			}
 		},
 		"Safari": {


### PR DESCRIPTION
I've added [COOP+COEP](https://web.dev/coop-coep/) headers to the feature test page, which unlocks powerful APIs like shared memory. In particular, This flips "threads" on Firefox stable to true!

cc @chicoxyzzy just to double-check on someone else's Firefox :)