### PR TITLE
Update Safari feature support

### DIFF
--- a/features.json
+++ b/features.json
@@ -95,7 +95,8 @@
 			"version": "13.1",
 			"features": {
 				"multiValue": true,
-				"mutableGlobals": true
+				"mutableGlobals": true,
+				"referenceTypes": "JSC_useWebAssemblyReferences"
 			}
 		},
 		"Wasmtime": {


### PR DESCRIPTION
Safari/JSC supports reference types behind the `JSC_useWebAssemblyReferences` runtime flag.