### PR TITLE
Update supported features of Wasmtime

### DIFF
--- a/features.json
+++ b/features.json
@@ -102,13 +102,13 @@
 		"Wasmtime": {
 			"url": "https://wasmtime.dev/",
 			"logo": "/images/bca.png",
-			"version": "0.17",
+			"version": "0.20",
 			"features": {
 				"bigInt": true,
-				"bulkMemory": "--enable-bulk-memory",
+				"bulkMemory": true,
 				"multiValue": true,
 				"mutableGlobals": true,
-				"referenceTypes": "--enable-reference-types",
+				"referenceTypes": true,
 				"saturatedFloatToInt": true,
 				"signExtensions": true,
 				"simd": "--enable-simd"


### PR DESCRIPTION
Bulk memory and reference types have been fully supported since 0.19 and enabled by default since 0.20.