### PR TITLE
Revert "Revert "Update supported features of Wasmtime (#193)""

### DIFF
--- a/features.json
+++ b/features.json
@@ -102,13 +102,13 @@
 		"Wasmtime": {
 			"url": "https://wasmtime.dev/",
 			"logo": "/images/bca.png",
-			"version": "0.17",
+			"version": "0.20",
 			"features": {
 				"bigInt": true,
-				"bulkMemory": "--enable-bulk-memory",
+				"bulkMemory": true,
 				"multiValue": true,
 				"mutableGlobals": true,
-				"referenceTypes": "--enable-reference-types",
+				"referenceTypes": true,
 				"saturatedFloatToInt": true,
 				"signExtensions": true,
 				"simd": "--enable-simd"


### PR DESCRIPTION
This reverts commit ca3384d3a36f8b0c4407cfa242f06de9a929c527.

The release is now tagged and on the github releases page: https://github.com/bytecodealliance/wasmtime/releases/tag/v0.20.0

@RReverser, PTAL. 