### PR TITLE
Update Community section

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -20,7 +20,7 @@
       <a class="site-nav-item btn" href="/getting-started/developers-guide/">Getting Started</a>
       <a class="site-nav-item btn" href="/specs">Specs</a>
       <a class="site-nav-item btn" href="/roadmap/">Future features</a>
-      <a class="site-nav-item btn" href="/community/feedback/">Community</a>
+      <a class="site-nav-item btn" href="/community/resources/">Community</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>
     </nav>
     </div>

--- a/_layouts/community.html
+++ b/_layouts/community.html
@@ -8,9 +8,9 @@
       <div class="col-xs-12 col-lg-3">
         <h6 class="side-title">Community</h6>
         <nav class="side-nav">
+          <a class="side-nav-item" href="/community/resources/">Resources</a>
           <a class="side-nav-item" href="/community/feedback/">Feedback</a>
           <a class="side-nav-item" href="/community/contributing/">Contributing</a>
-          <a class="side-nav-item" href="/community/events/">Past Events</a>
           <a class="side-nav-item" href="/community/code-of-conduct/">Code of Conduct</a>
           <a class="side-nav-item" href="https://www.w3.org/community/webassembly/">W3C Community Group ↳</a>
         </nav>

--- a/community/contributing.md
+++ b/community/contributing.md
@@ -14,7 +14,7 @@ Interested in participating? We suggest you start by:
 1. Acquainting yourself with the
    [Code of Ethics and Professional Conduct](/community/code-of-conduct/).
 2. Reading the [WebAssembly design][].
-3. Joining the IRC channel `irc://irc.w3.org:6667/#webassembly`.
+3. Joining the [Discord #cg chat](https://discord.gg/kx5VNQa).
 
 With that background understood and communication set up, feel free to
 [file issues][] in the WebAssembly design repository. Please join the

--- a/community/resources.md
+++ b/community/resources.md
@@ -1,0 +1,17 @@
+---
+layout: community
+---
+
+# Resources
+
+There's a lot of community-driven public discussion forums, chats and channels where you can get help with any WebAssembly-related questions, answer them for others, or subscribe to WebAssembly news.
+
+Here are just some of the popular ways to get started:
+
+- [Collection of awesome things in the Wasm ecosystem](https://github.com/mbasso/awesome-wasm)
+- [Reddit: r/WebAssembly](https://www.reddit.com/r/WebAssembly/)
+- [Discord chat](https://discord.gg/jwCC7jS)
+- [Stackoverflow: #webassembly tag](https://stackoverflow.com/questions/tagged/webassembly)
+- WebAssembly Weekly [newsletter](https://wasmweekly.news/) or [Twitter account](https://twitter.com/WasmWeekly).
+
+Interesting in contributing to WebAssembly? Check out the [Contributing](/contributing) page.

--- a/community/resources.md
+++ b/community/resources.md
@@ -14,4 +14,4 @@ Here are just some of the popular ways to get started:
 - [Stackoverflow: #webassembly tag](https://stackoverflow.com/questions/tagged/webassembly)
 - WebAssembly Weekly [newsletter](https://wasmweekly.news/) or [Twitter account](https://twitter.com/WasmWeekly).
 
-Interesting in contributing to WebAssembly? Check out the [Contributing](/contributing) page.
+Interesting in contributing to WebAssembly? Check out the [Contributing](/community/contributing/) page.


### PR DESCRIPTION

 - Add /resources page with some useful links for beginners.
 - Update the old IRC link in "Contributing" to a #cg Discord chat instead.
 - Hide outdated "Past events" page from the sidebar until we figure out how to sustainably maintain list of Wasm events.