### PR TITLE
Represent non-applicable roadmap features with 'N/A'. Fixes #171

### DIFF
--- a/features.json
+++ b/features.json
@@ -104,7 +104,7 @@
 			"logo": "/images/bca.png",
 			"version": "0.20",
 			"features": {
-				"bigInt": true,
+				"bigInt": null,
 				"bulkMemory": true,
 				"multiValue": true,
 				"mutableGlobals": true,
@@ -119,7 +119,7 @@
 			"logo": "/images/wasmer.png",
 			"version": "1.0",
 			"features": {
-				"bigInt": true,
+				"bigInt": null,
 				"bulkMemory": true,
 				"multiValue": true,
 				"mutableGlobals": true,

--- a/roadmap.md
+++ b/roadmap.md
@@ -100,7 +100,7 @@ After the initial release, WebAssembly has been gaining new features through the
                 return h('td', { title: support, tabIndex: 0 }, ['⏳']);
               }
               if (support === null) {
-                return h('td', { title: support, tabIndex: 0 }, ['➖']);
+                return h('td', { title: support, tabIndex: 0 }, ['ⁿ/ₐ']);
               }
               return h('td', {}, [support ? '✔️' : '❌']);
             })

--- a/roadmap.md
+++ b/roadmap.md
@@ -99,6 +99,9 @@ After the initial release, WebAssembly has been gaining new features through the
               if (typeof support === 'string') {
                 return h('td', { title: support, tabIndex: 0 }, ['⏳']);
               }
+              if (support === null) {
+                return h('td', { title: support, tabIndex: 0 }, ['➖']);
+              }
               return h('td', {}, [support ? '✔️' : '❌']);
             })
           ])


### PR DESCRIPTION
After looking at the various unicode options, I think minus ➖ makes the most sense.

Fixes #171

Sorry I couldn't test this, when I try to build I get this:
```
 Incremental build: disabled. Enable with --incremental
      Generating... 
  Liquid Exception: undefined method `includes_load_paths' for #<Jekyll::Site:0x000055c2eed09e70> in _layouts/getting-started.html
jekyll 3.1.6 | Error:  undefined method `includes_load_paths' for #<Jekyll::Site:0x000055c2eed09e70>
```

I can try again from my work machine tomorrow.