### PR TITLE
Update features.json with Safari 14.1 data

### DIFF
--- a/features.json
+++ b/features.json
@@ -97,11 +97,14 @@
 		"Safari": {
 			"url": "https://www.apple.com/safari/",
 			"logo": "/images/safari_48x48.png",
-			"version": "13.1",
+			"version": "14.1",
 			"features": {
+				"bigInt": true,
+				"bulkMemory": "JSC_useWebAssemblyReferences",
 				"multiValue": true,
 				"mutableGlobals": true,
-				"referenceTypes": "JSC_useWebAssemblyReferences"
+				"referenceTypes": "JSC_useWebAssemblyReferences",
+				"signExtensions": true,
 			}
 		},
 		"Wasmtime": {

--- a/features.json
+++ b/features.json
@@ -105,6 +105,7 @@
 				"mutableGlobals": true,
 				"referenceTypes": "JSC_useWebAssemblyReferences",
 				"signExtensions": true,
+				"threads": "JSC_useWebAssemblyThreading"
 			}
 		},
 		"Wasmtime": {

--- a/features.json
+++ b/features.json
@@ -100,10 +100,10 @@
 			"version": "14.1",
 			"features": {
 				"bigInt": true,
-				"bulkMemory": "JSC_useWebAssemblyReferences",
+				"bulkMemory": "JSC_useWebAssemblyReferences, enabled in Safari Technology Preview",
 				"multiValue": true,
 				"mutableGlobals": true,
-				"referenceTypes": "JSC_useWebAssemblyReferences",
+				"referenceTypes": "JSC_useWebAssemblyReferences, enabled in Safari Technology Preview",
 				"signExtensions": true,
 				"threads": "JSC_useWebAssemblyThreading"
 			}

--- a/features.json
+++ b/features.json
@@ -104,6 +104,7 @@
 				"multiValue": true,
 				"mutableGlobals": true,
 				"referenceTypes": "JSC_useWebAssemblyReferences, enabled in Safari Technology Preview",
+				"saturatedFloatToInt": "Enabled in Safari Technology Preview",
 				"signExtensions": true,
 				"threads": "JSC_useWebAssemblyThreading"
 			}


### PR DESCRIPTION
Safari 14.1 is available in macOS 11.3 Beta and iOS 14.5 Beta. Stable versions will probably be released in the end of March or early April.