### PR TITLE
Update flag for Firefox SIMD

### DIFF
--- a/features.json
+++ b/features.json
@@ -90,7 +90,7 @@
 				"referenceTypes": true,
 				"saturatedFloatToInt": true,
 				"signExtensions": true,
-				"simd": "Nightly, x86 and x86-64 only",
+				"simd": "about:config -> javascript.options.wasm_simd, x86 and x86-64 only",
 				"threads": true
 			}
 		},


### PR DESCRIPTION
It seems to be possible to enable it on stable too now.

@lars-t-hansen can you please confirm if it's still limited to x86 / x64?