### PR TITLE
Add memory64 row to feature table

### DIFF
--- a/features.json
+++ b/features.json
@@ -64,6 +64,11 @@
 			"description": "Threads and atomics",
 			"url": "https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md",
 			"phase": 2
+		},
+		"memory64": {
+			"description": "Memory64",
+			"url": "https://github.com/WebAssembly/memory64/blob/master/proposals/memory64/Overview.md",
+			"phase": 3
 		}
 	},
 	"browsers": {

--- a/features.json
+++ b/features.json
@@ -20,6 +20,11 @@
 			"url": "https://github.com/WebAssembly/extended-const/blob/master/proposals/extended-const/Overview.md",
 			"phase": 1
 		},
+		"memory64": {
+			"description": "Memory64",
+			"url": "https://github.com/WebAssembly/memory64/blob/master/proposals/memory64/Overview.md",
+			"phase": 3
+		},
 		"moduleLinking": {
 			"description": "Module Linking",
 			"url": "https://github.com/WebAssembly/module-linking/blob/master/proposals/module-linking/Explainer.md",
@@ -64,11 +69,6 @@
 			"description": "Threads and atomics",
 			"url": "https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md",
 			"phase": 2
-		},
-		"memory64": {
-			"description": "Memory64",
-			"url": "https://github.com/WebAssembly/memory64/blob/master/proposals/memory64/Overview.md",
-			"phase": 3
 		}
 	},
 	"browsers": {
@@ -126,10 +126,11 @@
 		"Wasmtime": {
 			"url": "https://wasmtime.dev/",
 			"logo": "/images/bca.png",
-			"version": "0.22",
+			"version": "0.31",
 			"features": {
 				"bigInt": null,
 				"bulkMemory": true,
+				"memory64": "--enable-memory64",
 				"moduleLinking": "--enable-module-linking",
 				"multiValue": true,
 				"mutableGlobals": true,


### PR DESCRIPTION
I had not been in the loop about the status of the memory64 proposal; I was pointed to https://webassembly.org/roadmap and, not seeing it there, thought it would be helpful to add a row for it.