### PR TITLE
Fix module linking explainer URL

### DIFF
--- a/features.json
+++ b/features.json
@@ -32,7 +32,7 @@
 		},
 		"moduleLinking": {
 			"description": "Module Linking",
-			"url": "https://github.com/WebAssembly/module-linking/blob/master/proposals/module-linking/Explainer.md",
+			"url": "https://github.com/WebAssembly/module-linking/blob/main/design/proposals/module-linking/Explainer.md",
 			"phase": 1
 		},
 		"multiValue": {


### PR DESCRIPTION
Currently used URL to the module linking proposal is 404.