### PR TITLE
CSS: prevent vertical scrolling of feature table on some Firefox configurations

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -1959,7 +1959,7 @@ pre code::before, pre code::after {
 }
 
 #feature-support-scrollbox {
-  overflow: auto;
+  overflow: auto hidden;
   margin: 0 0 16px 0;
 }
 


### PR DESCRIPTION
After the recent refactor (#283), the roadmap table shows a vertical scrollbar in some situations. This PR (allowing the table margin to be inherited) seems to fix the problem and doesn't seem to cause problems in Chrome or elsewhere.

E.g., here's Firefox on Ubuntu/X11 at the default 100% zoom level before this change: ![image](https://user-images.githubusercontent.com/208955/193962587-ce9e2abc-4162-4e42-953a-0abe70853ca6.png)

@andylizi 