### PR TITLE
Add more data to the feature table

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -31,7 +31,7 @@ nav a:hover {
     margin-right: auto;
     padding-left: 15px;
     padding-right: 15px;
-    max-width: 980px;
+    max-width: 1000px;
 }
 
 .container::after {

--- a/features.json
+++ b/features.json
@@ -41,7 +41,7 @@
 			"phase": 4
 		},
 		"mutableGlobals": {
-			"description": "Import & export of mutable globals",
+			"description": "Mutable globals",
 			"url": "https://github.com/WebAssembly/mutable-global/blob/master/proposals/mutable-global/Overview.md",
 			"phase": 4
 		},
@@ -147,16 +147,16 @@
 			"version": "0.33",
 			"features": {
 				"bigInt": null,
-				"bulkMemory": true,
-				"memory64": ["flag", "Requires flag `--enable-memory64`"],
-				"multiMemory": ["flag", "Requires flag `--enable-multi-memory`"],
-				"moduleLinking": ["flag", "Requires flag `--enable-module-linking`"],
-				"multiValue": true,
+				"bulkMemory": "0.20",
+				"memory64": ["flag", "Requires flag `--wasm-features=memory64`"],
+				"multiMemory": ["flag", "Requires flag `--wasm-features=multi-memory`"],
+				"multiValue": "0.17",
 				"mutableGlobals": true,
-				"referenceTypes": true,
+				"referenceTypes": "0.20",
 				"saturatedFloatToInt": true,
 				"signExtensions": true,
-				"simd": true
+				"simd": "0.33",
+				"threads": ["flag", "Requires flag `--wasm-features=threads`"]
 			}
 		},
 		"Wasmer": {
@@ -164,13 +164,13 @@
 			"logo": "/images/wasmer.svg",
 			"features": {
 				"bigInt": null,
-				"bulkMemory": true,
-				"multiValue": true,
-				"mutableGlobals": true,
-				"referenceTypes": true,
+				"bulkMemory": "1.0",
+				"multiValue": "1.0",
+				"mutableGlobals": "0.7",
+				"referenceTypes": "2.0",
 				"saturatedFloatToInt": true,
 				"signExtensions": true,
-				"simd": true,
+				"simd": "2.0",
 				"threads": ["flag", "Requires flag `--enable-threads`"]
 			}
 		},
@@ -179,17 +179,20 @@
 			"logo": "/images/nodejs.svg",
 			"features": {
 				"bigInt": true,
-				"bulkMemory": true,
-				"exceptions": ["flag", "Requires flag `--experimental-wasm-eh`"],
+				"bulkMemory": "12.5",
+				"exceptions": "17.0",
 				"extendedConst": ["flag", "Requires flag `--experimental-wasm-extended-const`"],
-				"multiValue": true,
-				"mutableGlobals": true,
-				"referenceTypes": ["flag", "Requires flag `--experimental-wasm-reftypes`"],
-				"saturatedFloatToInt": true,
-				"signExtensions": true,
-				"simd": true,
+				"memory64": ["flag", "Requires flag `--experimental-wasm-memory64`"],
+				"multiValue": "15.0",
+				"mutableGlobals": "12.0",
+				"referenceTypes": "17.2",
+				"relaxedSimd": ["flag", "Requires flag `--experimental-wasm-relaxed-simd`"],
+				"saturatedFloatToInt": "12.5",
+				"signExtensions": "12.0",
+				"simd": "16.4",
 				"tailCall": ["flag", "Requires flag `--experimental-wasm-return-call`"],
-				"threads": true
+				"threads": "16.4",
+				"typeReflection": ["flag", "Requires flag `--experimental-wasm-type-reflection`"]
 			}
 		},
 		"Deno": {
@@ -197,16 +200,20 @@
 			"logo": "/images/deno.svg",
 			"features": {
 				"bigInt": true,
-				"bulkMemory": true,
-				"exceptions": true,
-				"multiValue": true,
-				"mutableGlobals": true,
-				"referenceTypes": true,
-				"saturatedFloatToInt": true,
-				"signExtensions": true,
-				"simd": true,
-				"tailCall": false,
-				"threads": true
+				"bulkMemory": "0.4",
+				"exceptions": "1.16",
+				"extendedConst": ["flag", "Requires flag `--v8-flags=\"--experimental-wasm-extended-const\"`"],
+				"memory64": ["flag", "Requires flag `--v8-flags=\"--experimental-wasm-memory64`\""],
+				"multiValue": "1.3.2",
+				"mutableGlobals": "0.1",
+				"referenceTypes": "1.16",
+				"relaxedSimd": ["flag", "Requires flag `--v8-flags=\"--experimental-wasm-relaxed-simd\"`"],
+				"saturatedFloatToInt": "0.4",
+				"signExtensions": "0.1",
+				"simd": "1.9",
+				"tailCall": ["flag", "Requires flag `--v8-flags=\"--experimental-wasm-return-call\"`"],
+				"threads": "1.9",
+				"typeReflection": ["flag", "Requires flag `--v8-flags=\"--experimental-wasm-type-reflection\"`"]
 			}
 		}
 	}

--- a/features.json
+++ b/features.json
@@ -94,8 +94,8 @@
 				"bigInt": "85",
 				"bulkMemory": "75",
 				"exceptions": "95",
-				"extendedConst": ["flag", "Requires flag `--js-flags=--experimental-wasm-extended-const`"],
-				"memory64": ["flag", "Requires flag `--js-flags=--experimental-wasm-memory64`"],
+				"extendedConst": ["flag", "Requires corresponding v8 flag (`--js-flags=\"...\"`)"],
+				"memory64": ["flag", "Requires corresponding v8 flag (`--js-flags=\"...\"`)"],
 				"multiValue": "85",
 				"mutableGlobals": "74",
 				"referenceTypes": "96",
@@ -148,15 +148,15 @@
 			"features": {
 				"bigInt": null,
 				"bulkMemory": "0.20",
-				"memory64": ["flag", "Requires flag `--wasm-features=memory64`"],
-				"multiMemory": ["flag", "Requires flag `--wasm-features=multi-memory`"],
+				"memory64": ["flag", "Requires flag `--wasm-features=...`"],
+				"multiMemory": ["flag", "Requires flag `--wasm-features=...`"],
 				"multiValue": "0.17",
 				"mutableGlobals": true,
 				"referenceTypes": "0.20",
 				"saturatedFloatToInt": true,
 				"signExtensions": true,
 				"simd": "0.33",
-				"threads": ["flag", "Requires flag `--wasm-features=threads`"]
+				"threads": ["flag", "Requires flag `--wasm-features=...`"]
 			}
 		},
 		"Wasmer": {
@@ -181,18 +181,18 @@
 				"bigInt": true,
 				"bulkMemory": "12.5",
 				"exceptions": "17.0",
-				"extendedConst": ["flag", "Requires flag `--experimental-wasm-extended-const`"],
-				"memory64": ["flag", "Requires flag `--experimental-wasm-memory64`"],
+				"extendedConst": ["flag", "Requires corresponding v8 flag"],
+				"memory64": ["flag", "Requires corresponding v8 flag"],
 				"multiValue": "15.0",
 				"mutableGlobals": "12.0",
 				"referenceTypes": "17.2",
-				"relaxedSimd": ["flag", "Requires flag `--experimental-wasm-relaxed-simd`"],
+				"relaxedSimd": ["flag", "Requires corresponding v8 flag"],
 				"saturatedFloatToInt": "12.5",
 				"signExtensions": "12.0",
 				"simd": "16.4",
-				"tailCall": ["flag", "Requires flag `--experimental-wasm-return-call`"],
+				"tailCall": ["flag", "Requires corresponding v8 flag"],
 				"threads": "16.4",
-				"typeReflection": ["flag", "Requires flag `--experimental-wasm-type-reflection`"]
+				"typeReflection": ["flag", "Requires corresponding v8 flag"]
 			}
 		},
 		"Deno": {
@@ -202,18 +202,18 @@
 				"bigInt": true,
 				"bulkMemory": "0.4",
 				"exceptions": "1.16",
-				"extendedConst": ["flag", "Requires flag `--v8-flags=\"--experimental-wasm-extended-const\"`"],
-				"memory64": ["flag", "Requires flag `--v8-flags=\"--experimental-wasm-memory64`\""],
+				"extendedConst": ["flag", "Requires corresponding v8 flag (`--v8-flags=\"...\"`)"],
+				"memory64": ["flag", "Requires corresponding v8 flag (`--v8-flags=\"...\"`)"],
 				"multiValue": "1.3.2",
 				"mutableGlobals": "0.1",
 				"referenceTypes": "1.16",
-				"relaxedSimd": ["flag", "Requires flag `--v8-flags=\"--experimental-wasm-relaxed-simd\"`"],
+				"relaxedSimd": ["flag", "Requires corresponding v8 flag (`--v8-flags=\"...\"`)"],
 				"saturatedFloatToInt": "0.4",
 				"signExtensions": "0.1",
 				"simd": "1.9",
-				"tailCall": ["flag", "Requires flag `--v8-flags=\"--experimental-wasm-return-call\"`"],
+				"tailCall": ["flag", "Requires corresponding v8 flag (`--v8-flags=\"...\"`)"],
 				"threads": "1.9",
-				"typeReflection": ["flag", "Requires flag `--v8-flags=\"--experimental-wasm-type-reflection\"`"]
+				"typeReflection": ["flag", "Requires corresponding v8 flag (`--v8-flags=\"...\"`)"]
 			}
 		}
 	}


### PR DESCRIPTION
I've collected a bunch of version data for the feature table.

![preview](https://user-images.githubusercontent.com/12008103/194001030-8869a04a-0fc3-44f8-b638-23dd7d66f3fb.png)

### Wasmtime

|  Feature | Version | Source |
| --- | --- | --- |
| multi-value | 0.17 | https://github.com/bytecodealliance/wasmtime/pull/1667 |
| bulk-memory | 0.20 | https://github.com/WebAssembly/website/pull/193 |
| reference-types | 0.20 | https://github.com/WebAssembly/website/pull/193 |
| simd | 0.33 | https://github.com/bytecodealliance/wasmtime/pull/3601 |

### Wasmer

|  Feature | Version | Source |
| --- | --- | --- |
| mutable-globals | 0.7 | https://github.com/wasmerio/wasmer/pull/623 |
| bulk-memory | 1.0 | https://github.com/wasmerio/wasmer/commit/b3fbf79ecf60ae4368b27da7e14f492d30360dc3 |
| multi-value | 1.0 | https://github.com/wasmerio/wasmer/commit/bd2b648ca14764a1258167ed78465c5eb087617a |
| reference-types | 2.0 | https://github.com/wasmerio/wasmer/commit/92af25a5859b95d6c76e5de5cdd90008dc564b9f |
| simd | 2.0 | https://github.com/wasmerio/wasmer/commit/3d9656df8679c8704e8351409755b699e0efdb1a |

I'm unable to find the versions for some old proposals like sign extensions and saturating f2i conversions. The relevant logic in both wasmer and wasmtime was refactored a lot since then, I'm unable to trace it back enough to confidently say which versions were they first introduced.

### V8

|  Feature | Version | Source |
| --- | --- | --- |
| mutable-globals | 6.9 | https://github.com/v8/v8/commit/7ce76fbc340e61dc0021ef497bf6bb6cecda20e0 |
| sign-extension | 6.9 | https://github.com/v8/v8/commit/66f3e8f64deec7c1dbbe2c0a34bcbfc4df520272 |
| bulk-memory | 7.5 | https://github.com/v8/v8/commit/4e57789f26f3de83fb961ad1e9a52c3151bcc8df |
| sat-f2i-conversions | 7.5 | https://github.com/v8/v8/commit/efe01b881939f6efa1ae7e73bce73094b1c417ab |
| multi-value | 8.6 | https://github.com/v8/v8/commit/65d28a7fe4d83c8cb70f2f9fd293e36db3db55f1 |
| simd | 9.1 | https://github.com/v8/v8/commit/10587a273d615d4550908013470461e2cfd837f7 |
| threads | 9.1 | https://github.com/v8/v8/commit/be9ff65a06963f9326756c056a338e1b9e07499c |
| exception-handling | 9.5 | https://github.com/v8/v8/commit/906459f1423e140bc789660b48143c331f183b8a |
| reference-types | 9.6 | https://github.com/v8/v8/commit/c96864e0181eefeaecba12340296e3f085fcfa24 |

### Node.js

`v8 -> node` version data from https://nodejs.org/en/download/releases/.

| Feature | V8 Version | Node Version |
| --- | --- | --- |
| mutable-globals | 6.9 | 12.0 |
| sign-extension | 6.9 | 12.0 |
| bulk-memory | 7.5 | 12.5 |
| sat-f2i-conversions | 7.5 | 12.5 |
| multi-value | 8.6 | 15.0 |
| simd | 9.1 | 16.4 |
| threads | 9.1 | 16.4 |
| exception-handling | 9.5 | 17.0 |
| reference-types | 9.6 | 17.2 |

### Deno

`v8 -> rusty_v8 -> deno` version data from [release notes](https://github.com/denoland/deno/blob/main/Releases.md) and (sometimes) [git history](https://github.com/denoland/rusty_v8/commits/main/README.md).

| Feature | V8 Version | `rusty_v8` Version | Deno version | Source |
| --- | --- | --- | --- | --- |
| mutable-globals | 6.9 | N/A | 0.1.0 | https://github.com/denoland/deno/blob/v0.1.0/gclient_config.py#L2 |
| sign-extension | 6.9 | N/A | 0.1.0 | https://github.com/denoland/deno/blob/v0.1.0/gclient_config.py#L2 |
| bulk-memory | 7.5 | - | 0.4.0 | https://github.com/denoland/deno/blob/main/Releases.md#v040--20190503 |
| sat-f2i-conversions | 7.5 | - | 0.4.0 | https://github.com/denoland/deno/blob/main/Releases.md#v040--20190503 |
| multi-value | 8.6 | 0.8.0 | 1.3.2 | https://github.com/denoland/deno/blob/main/Releases.md#132--20200829 |
| simd | 9.1 | 0.22.0 | 1.9.0 | https://github.com/denoland/deno/pull/10152 |
| threads | 9.1 | 0.22.0 | 1.9.0 | https://github.com/denoland/deno/pull/10152 |
| exception-handling | 9.5 | 0.33.0 | 1.16.0 | https://github.com/denoland/deno/pull/12564 |
| reference-types | 9.6 | 0.33.0 | 1.16.0 | https://github.com/denoland/deno/pull/12564 |

---

I've also changed the tooltips for v8 flags. Before, we would need to write three tooltips for the three "wrappers" of v8, for every feature flag of v8, like so:

* Requires flag `--experimental-wasm-memory64` <sup>(node)</sup>
* Requires flag `--v8-flags="--experimental-wasm-memory64"` <sup>(deno)</sup>
* Requires flag `--js-flags=--experimental-wasm-memory64` <sup>(chrome)</sup>
* Requires flag `--experimental-wasm-extended-const`
* Requires flag `--v8-flags="--experimental-wasm-extended-const"`
* Requires flag `--js-flags=--experimental-wasm-extended-const`
* ...

This feels quite redundant to me, so I changed them to:

* Requires corresponding v8 flag <sup>(node)</sup>
* Requires corresponding v8 flag (`--v8-flags="..."`) <sup>(deno)</sup>
* Requires corresponding v8 flag (`--js-flags="..."`) <sup>(chrome)</sup>

---

By the way, is the [Module Linking](https://github.com/WebAssembly/module-linking) proposal still relevant today? From what I can tell, it was superseded by the [Component Model](https://github.com/WebAssembly/component-model). Should I replaced it with data from component model?