### PR TITLE
Add minimum version for node bigint integration

### DIFF
--- a/features.json
+++ b/features.json
@@ -182,7 +182,7 @@
 			"url": "https://nodejs.org/",
 			"logo": "/images/nodejs.svg",
 			"features": {
-				"bigInt": true,
+				"bigInt": "16.0",
 				"bulkMemory": "12.5",
 				"exceptions": "17.0",
 				"extendedConst": ["flag", "Requires flag `--experimental-wasm-extended-const`"],

--- a/features.json
+++ b/features.json
@@ -182,7 +182,7 @@
 			"url": "https://nodejs.org/",
 			"logo": "/images/nodejs.svg",
 			"features": {
-				"bigInt": "16.0",
+				"bigInt": "15.0",
 				"bulkMemory": "12.5",
 				"exceptions": "17.0",
 				"extendedConst": ["flag", "Requires flag `--experimental-wasm-extended-const`"],


### PR DESCRIPTION
Node first supported bigint integration in version 16.0, or in version 14.x and 15.x with `--experimental-wasm-bigint`.