### PR TITLE
Update Wasmtime flags

### DIFF
--- a/features.json
+++ b/features.json
@@ -152,8 +152,8 @@
 			"features": {
 				"bigInt": null,
 				"bulkMemory": "0.20",
-				"memory64": ["flag", "Requires flag `--enable-memory64`"],
-				"multiMemory": ["flag", "Requires flag `--enable-multi-memory`"],
+				"memory64": ["flag", "Requires flag `--wasm-features=memory64`"],
+				"multiMemory": ["flag", "Requires flag `--wasm-features=multi-memory`"],
 				"multiValue": "0.17",
 				"mutableGlobals": true,
 				"referenceTypes": "0.20",


### PR DESCRIPTION
This was a part of the reverted #313; this provides the correct flag syntax for several off-by-default features.