### PR TITLE
Kotlin: Link to new Wasm target

### DIFF
--- a/getting-started/developers-guide.md
+++ b/getting-started/developers-guide.md
@@ -15,7 +15,7 @@ layout: getting-started
   - Go
     - [with full language support](https://github.com/golang/go/wiki/WebAssembly#getting-started)
     - [targeting minimal size](https://tinygo.org/docs/guides/webassembly/)
-  - [Kotlin](https://kotlinlang.org/docs/reference/native-overview.html)
+  - [Kotlin](https://kotlinlang.org/docs/whatsnew-eap.html#new-kotlin-wasm-target)
   - [Swift](https://swiftwasm.org/)
   - [D](https://wiki.dlang.org/Generating_WebAssembly_with_LDC)
   - [Pascal](https://wiki.freepascal.org/WebAssembly/Compiler)


### PR DESCRIPTION
Before 1.8.20-Beta (released 2023-02-08), wasm was implemented as a native target using llvm. 1.8.20 contains an experimental new compiler backend. 