### PR TITLE
features: remove Module Linking

### DIFF
--- a/features.json
+++ b/features.json
@@ -36,11 +36,6 @@
 			"url": "https://github.com/WebAssembly/multi-memory/blob/master/proposals/multi-memory/Overview.md",
 			"phase": 3
 		},
-		"moduleLinking": {
-			"description": "Module Linking",
-			"url": "https://github.com/WebAssembly/module-linking/blob/main/design/proposals/module-linking/Explainer.md",
-			"phase": 1
-		},
 		"multiValue": {
 			"description": "Multi-value",
 			"url": "https://github.com/WebAssembly/spec/blob/master/proposals/multi-value/Overview.md",


### PR DESCRIPTION
The [Module Linking](https://github.com/WebAssembly/module-linking#readme) proposal is [suspended](https://github.com/WebAssembly/proposals/blob/main/inactive-proposals.md) in favor of the Component Model and currently inactive. It seems a bit out of place to keep it on the roadmap, which doesn't even include active phase 1 proposals.