### PR TITLE
Added Deno minimum version for bigint proposal

### DIFF
--- a/features.json
+++ b/features.json
@@ -209,7 +209,7 @@
 			"url": "https://deno.land/",
 			"logo": "/images/deno.svg",
 			"features": {
-				"bigInt": true,
+				"bigInt": "1.1.2",
 				"bulkMemory": "0.4",
 				"exceptions": "1.16",
 				"extendedConst": ["flag", "Requires flag `--v8-flags=--experimental-wasm-extended-const`"],


### PR DESCRIPTION
Added information for the version of Deno (1.1.2) which first enabled support for the experimental "JS BigInt to Wasm i64 integration" proposal.

This is according to https://github.com/denoland/deno/releases?page=13.