### PR TITLE
Added typeReflection feature in Wasmer

### DIFF
--- a/features.json
+++ b/features.json
@@ -176,7 +176,8 @@
 				"saturatedFloatToInt": true,
 				"signExtensions": true,
 				"simd": "2.0",
-				"threads": null
+				"threads": null,
+				"typeReflection": "2.0"
 			}
 		},
 		"Node.js": {


### PR DESCRIPTION
Wasmer has supported typeReflection in both the sys and js targets since 2.0 (in the sys feature since 1.0).
This PR reflects that on the feature set for Wasmer.

> Note: we support it in js thanks to a polyfill made with wasmparser, hopefully that will go away once TypeReflection is properly supported by most of browsers.

Thanks!