### PR TITLE
Update Chrome flag for extended-const proposal

### DIFF
--- a/features.json
+++ b/features.json
@@ -95,7 +95,7 @@
 				"bigInt": "85",
 				"bulkMemory": "75",
 				"exceptions": "95",
-				"extendedConst": ["flag", "Requires flag `--js-flags=--experimental-wasm-extended-const`"],
+				"extendedConst": ["flag", "Requires flag `chrome://flags/#enable-experimental-webassembly-features`"],
 				"gc": ["flag", "Requires flag `chrome://flags/#enable-webassembly-garbage-collection`"],
 				"memory64": ["flag", "Requires flag `chrome://flags/#enable-experimental-webassembly-features`"],
 				"multiValue": "85",


### PR DESCRIPTION
extended-const has been staged (https://bugs.chromium.org/p/chromium/issues/detail?id=1416400#c4) meaning it's now available behind the general "experimental webassembly features" flag.