### PR TITLE
Mark extended-const as shipped in Firefox 112

### DIFF
--- a/features.json
+++ b/features.json
@@ -117,7 +117,7 @@
 				"bigInt": "78",
 				"bulkMemory": "79",
 				"exceptions": "100",
-				"extendedConst": ["flag", "Enabled in Nightly, unavailable in Beta/Release"],
+				"extendedConst": "112",
 				"memory64": ["flag", "Enabled in Nightly, unavailable in Beta/Release"],
 				"multiValue": "78",
 				"mutableGlobals": "61",


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1814421