### PR TITLE
Add JSPI to the roadmap.

### DIFF
--- a/features.json
+++ b/features.json
@@ -26,6 +26,11 @@
 			"url":"https://github.com/WebAssembly/gc",
 			"phase": 3
 		},
+		"jspi": {
+			"description": "JS Promise Integration",
+			"url":"https://github.com/WebAssembly/js-promise-integration",
+			"phase": 3
+		},
 		"memory64": {
 			"description": "Memory64",
 			"url": "https://github.com/WebAssembly/memory64/blob/master/proposals/memory64/Overview.md",
@@ -97,6 +102,7 @@
 				"exceptions": "95",
 				"extendedConst": "114",
 				"gc": ["flag", "Requires flag `chrome://flags/#enable-webassembly-garbage-collection`"],
+				"jspi": ["flag", "Requires flag `chrome://flags/#enable-experimental-webassembly-stack-switching`"],
 				"memory64": ["flag", "Requires flag `chrome://flags/#enable-experimental-webassembly-features`"],
 				"multiValue": "85",
 				"mutableGlobals": "74",
@@ -188,6 +194,7 @@
 				"bulkMemory": "12.5",
 				"exceptions": "17.0",
 				"extendedConst": ["flag", "Requires flag `--experimental-wasm-extended-const`"],
+				"jspi": ["flag", "Requires flag `--experimental-wasm-stack-switching`"],
 				"memory64": ["flag", "Requires flag `--experimental-wasm-memory64`"],
 				"multiValue": "15.0",
 				"mutableGlobals": "12.0",
@@ -209,6 +216,7 @@
 				"bulkMemory": "0.4",
 				"exceptions": "1.16",
 				"extendedConst": ["flag", "Requires flag `--v8-flags=--experimental-wasm-extended-const`"],
+				"jspi": ["flag", "Requires flag `--v8-flags=--experimental-stack-switching`"],
 				"memory64": ["flag", "Requires flag `--v8-flags=--experimental-wasm-memory64`"],
 				"multiValue": "1.3.2",
 				"mutableGlobals": "0.1",


### PR DESCRIPTION
Note: the feature detection library release doesn't have jspi yet, so we'll have to update that later.