### PR TITLE
[Roadmap] Nodejs implements GC behind a flag

### DIFF
--- a/features.json
+++ b/features.json
@@ -201,6 +201,7 @@
 				"bulkMemory": "12.5",
 				"exceptions": "17.0",
 				"extendedConst": ["flag", "Requires flag `--experimental-wasm-extended-const`"],
+				"gc": ["flag", "Requires flag `--experimental-wasm-gc`"],
 				"jspi": ["flag", "Requires flag `--experimental-wasm-stack-switching`"],
 				"memory64": ["flag", "Requires flag `--experimental-wasm-memory64`"],
 				"multiValue": "15.0",


### PR DESCRIPTION
Excerpt from node --v8-options:

    --experimental-wasm-gc (enable prototype garbage collection for wasm)
          type: bool  default: --noexperimental-wasm-gc

From what I can tell the flag is available since at least node 16