### PR TITLE
Update wasm2c status for tail calls

### DIFF
--- a/features.json
+++ b/features.json
@@ -249,6 +249,7 @@
 				"jspi": null,
 				"memory64": ["flag", "Requires flag `--enable-memory64`"],
 				"multiMemory": ["flag", "Requires flag `--enable-multi-memory`"],
+				"tailCall": ["flag", "Requires flag `--enable-tail-call`"],
 				"multiValue": "1.0.24",
 				"mutableGlobals": "1.0.1",
 				"referenceTypes": "1.0.31",


### PR DESCRIPTION
wasm2c added support for tail calls behind a flag in version 1.0.34 (https://github.com/WebAssembly/wabt/releases/tag/1.0.34).