### PR TITLE
Switch to evergreen URL for wasm-feature-detect library

### DIFF
--- a/roadmap.js
+++ b/roadmap.js
@@ -384,8 +384,10 @@
   }
 
   function _loadFeatureDetectModule() {
-    // Be sure to change the preloads in markdown when updating url.
-    const module = import('https://cdn.jsdelivr.net/npm/wasm-feature-detect/dist/esm/index.js');
+    // Please cache bust by bumping the `v` parameter whenever `feature.json` is
+    // updated to depend on a new version of the library. See #353 for discussion.
+    // Make sure to also match the preload link in `roadmap.md`.
+    const module = import('https://unpkg.com/wasm-feature-detect@1/dist/esm/index.js?v=1');
     return (featureName) => module
       .then(wasmFeatureDetect => wasmFeatureDetect[featureName]());
   }

--- a/roadmap.js
+++ b/roadmap.js
@@ -385,7 +385,7 @@
 
   function _loadFeatureDetectModule() {
     // Be sure to change the preloads in markdown when updating url.
-    const module = import('https://unpkg.com/wasm-feature-detect@latest/dist/esm/index.js');
+    const module = import('https://cdn.jsdelivr.net/npm/wasm-feature-detect/dist/esm/index.js');
     return (featureName) => module
       .then(wasmFeatureDetect => wasmFeatureDetect[featureName]());
   }

--- a/roadmap.js
+++ b/roadmap.js
@@ -139,7 +139,7 @@
     );
     for (const { name: featName, description, url } of features) {
       const detectResult = h('td', {
-        headers: [idMap['table-col']('Your browser'), idMap['table-row'](featName)].join(' ') 
+        headers: [idMap['table-col']('Your browser'), idMap['table-row'](featName)].join(' ')
       }, [buildCellInner('loading')]);
 
       detectWasmFeature(featName).then(supported => {
@@ -385,7 +385,7 @@
 
   function _loadFeatureDetectModule() {
     // Be sure to change the preloads in markdown when updating url.
-    const module = import('https://cdn.jsdelivr.net/npm/wasm-feature-detect@1.5/dist/esm/index.js');
+    const module = import('https://unpkg.com/wasm-feature-detect@latest/dist/esm/index.js');
     return (featureName) => module
       .then(wasmFeatureDetect => wasmFeatureDetect[featureName]());
   }

--- a/roadmap.md
+++ b/roadmap.md
@@ -32,7 +32,7 @@ The table below aims to track implemented features in popular engines:
 </div>
 <link rel="preload" href="/features.json" as="fetch">
 <script src="/roadmap.js"></script>
-<link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/wasm-feature-detect/dist/esm/index.js">
+<link rel="modulepreload" href="https://unpkg.com/wasm-feature-detect@1/dist/esm/index.js?v=1">
 <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/@floating-ui/dom@1/+esm">
 
 To detect supported features at runtime from JavaScript, check out the [`wasm-feature-detect` library](https://github.com/GoogleChromeLabs/wasm-feature-detect), which powers the "Your browser" column above.

--- a/roadmap.md
+++ b/roadmap.md
@@ -32,7 +32,7 @@ The table below aims to track implemented features in popular engines:
 </div>
 <link rel="preload" href="/features.json" as="fetch">
 <script src="/roadmap.js"></script>
-<link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/wasm-feature-detect@1/dist/esm/index.js">
+<link rel="modulepreload" href="https://unpkg.com/wasm-feature-detect@latest/dist/esm/index.js">
 <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/@floating-ui/dom@1/+esm">
 
 To detect supported features at runtime from JavaScript, check out the [`wasm-feature-detect` library](https://github.com/GoogleChromeLabs/wasm-feature-detect), which powers the "Your browser" column above.

--- a/roadmap.md
+++ b/roadmap.md
@@ -32,7 +32,7 @@ The table below aims to track implemented features in popular engines:
 </div>
 <link rel="preload" href="/features.json" as="fetch">
 <script src="/roadmap.js"></script>
-<link rel="modulepreload" href="https://unpkg.com/wasm-feature-detect@latest/dist/esm/index.js">
+<link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/wasm-feature-detect/dist/esm/index.js">
 <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/@floating-ui/dom@1/+esm">
 
 To detect supported features at runtime from JavaScript, check out the [`wasm-feature-detect` library](https://github.com/GoogleChromeLabs/wasm-feature-detect), which powers the "Your browser" column above.


### PR DESCRIPTION
Use https://unpkg.com/wasm-feature-detect@latest/dist/esm/index.js so we always include the latest build dynamically.