### PR TITLE
Update features for wasmtime 15

### DIFF
--- a/features.json
+++ b/features.json
@@ -165,16 +165,16 @@
 				"bulkMemory": "0.20",
 				"jspi": null,
 				"memory64": ["flag", "Requires flag `--wasm-features=memory64`"],
-				"multiMemory": ["flag", "Requires flag `--wasm-features=multi-memory`"],
+				"multiMemory": "15",
 				"multiValue": "0.17",
 				"mutableGlobals": true,
 				"referenceTypes": "0.20",
-				"relaxedSimd": ["flag", "Requires flag `--wasm-features=relaxed-simd`"],
+				"relaxedSimd": "15",
 				"saturatedFloatToInt": true,
 				"signExtensions": true,
 				"simd": "0.33",
 				"tailCall": ["flag", "Requires flag `--wasm-features=tail-call`"],
-				"threads": ["flag", "Requires flag `--wasm-features=threads`"]
+				"threads": "15"
 			}
 		},
 		"Wasmer": {


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime/releases/tag/v15.0.0

> The WebAssembly threads, multi-memory, and relaxed-simd proposals are now enabled by default.
> https://github.com/bytecodealliance/wasmtime/pull/7285

I wasn't sure whether to specify the version as "15" or "15.0" (or even "15.0.0"). It seems to be inconsistent in the table. I used 15, as wasmtime's releases are similar to a browser where on a fixed schedule they bump the major version and bugfixes are done as patch versions (minor versions aren't used).