### PR TITLE
Rename roadmap to "feature extensions"

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -18,7 +18,7 @@
       <a class="site-nav-item btn" href="/">Overview</a>
       <a class="site-nav-item btn" href="/getting-started/developers-guide/">Getting Started</a>
       <a class="site-nav-item btn" href="/specs">Specs</a>
-      <a class="site-nav-item btn" href="/roadmap/">Future features</a>
+      <a class="site-nav-item btn" href="/features/">Feature Extensions</a>
       <a class="site-nav-item btn" href="/community/resources/">Community</a>
       <a class="site-nav-item btn" href="/docs/faq/">FAQ</a>
     </nav>
@@ -33,7 +33,7 @@
         &nbsp;<img width="48" height="48" src="/images/chrome.svg" alt="Chrome"/>
         &nbsp;<img width="48" height="48" src="/images/safari.svg" alt="Safari"/>
         &nbsp;<img width="48" height="48" src="/images/edge.svg" alt="Edge"/>
-        &nbsp;&#8203;<a href="/roadmap/">Learn&nbsp;more</a></span>
+        &nbsp;&#8203;<a href="/features/">Learn&nbsp;more</a></span>
     </div>
   </section>
   {% if page.lead %}

--- a/community/feedback.md
+++ b/community/feedback.md
@@ -6,11 +6,6 @@ layout: community
 
 We welcome community and developer feedback on all aspects of WebAssembly, including the high-level design, binary format, JS API, developer experience, and browser implementations.
 
-<!--
-<div class="flash flash-warn">
-  We're especially interested in hearing from developers during the <a href="/roadmap/">Browser Preview</a> period, while WebAssembly is still implemented behind a flag.
-</div>
--->
 
 Please contribute your feedback or issues in the following forums:
 

--- a/features.js
+++ b/features.js
@@ -386,7 +386,7 @@
   function _loadFeatureDetectModule() {
     // Please cache bust by bumping the `v` parameter whenever `feature.json` is
     // updated to depend on a new version of the library. See #353 for discussion.
-    // Make sure to also match the preload link in `roadmap.md`.
+    // Make sure to also match the preload link in `features.md`.
     const module = import('https://unpkg.com/wasm-feature-detect@1/dist/esm/index.js?v=1');
     return (featureName) => module
       .then(wasmFeatureDetect => wasmFeatureDetect[featureName]());

--- a/features.md
+++ b/features.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 ---
-# Roadmap
+# Feature Extensions
 
 In November 2017, WebAssembly CG members representing four browsers, Chrome, Edge, Firefox, and WebKit, reached consensus that the design of the initial (MVP) WebAssembly API and binary format is complete to the extent that no further design work is possible without implementation experience and significant usage.
 
@@ -31,7 +31,7 @@ The table below aims to track implemented features in popular engines:
   <table id="feature-support" aria-label="Status of implemented features in popular engines"></table>
 </div>
 <link rel="preload" href="/features.json" as="fetch">
-<script src="/roadmap.js"></script>
+<script src="/features.js"></script>
 <link rel="modulepreload" href="https://unpkg.com/wasm-feature-detect@1/dist/esm/index.js?v=1">
 <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/@floating-ui/dom@1/+esm">
 


### PR DESCRIPTION
When this page was created along with the wasm MVP, all the listed features were in the future, so it served as a roadmap for what was to come. Now it includes all the feature extensions that have been added since, and its primary usefulness is actually for developers to look up which engine versions implement which features (including past and near-future features which have implementations behind flags). So a better name than "roadmap" or "future features" would be something like "feature extensions". 

Also fixes #329 