### PR TITLE
Update Node status for GC

### DIFF
--- a/features.json
+++ b/features.json
@@ -201,7 +201,7 @@
 				"bulkMemory": "12.5",
 				"exceptions": "17.0",
 				"extendedConst": ["flag", "Requires flag `--experimental-wasm-extended-const`"],
-				"gc": ["flag", "Requires flag `--experimental-wasm-gc; the new opcodes are only supported in v22.0.0-nightly2024010568c8472ed9 or newer`"],
+				"gc": "22.0",
 				"jspi": ["flag", "Requires flag `--experimental-wasm-stack-switching`"],
 				"memory64": ["flag", "Requires flag `--experimental-wasm-memory64`"],
 				"multiMemory": ["flag", "Requires flag `--experimental-wasm-multi-memory`"],

--- a/features.json
+++ b/features.json
@@ -201,7 +201,7 @@
 				"bulkMemory": "12.5",
 				"exceptions": "17.0",
 				"extendedConst": ["flag", "Requires flag `--experimental-wasm-extended-const`"],
-				"gc": ["flag", "Requires flag `--experimental-wasm-gc`"],
+				"gc": ["flag", "Requires flag `--experimental-wasm-gc; the new opcodes are only supported in v22.0.0-nightly2024010568c8472ed9 or newer`"],
 				"jspi": ["flag", "Requires flag `--experimental-wasm-stack-switching`"],
 				"memory64": ["flag", "Requires flag `--experimental-wasm-memory64`"],
 				"multiMemory": ["flag", "Requires flag `--experimental-wasm-multi-memory`"],


### PR DESCRIPTION
Using [Binaryen v116](https://github.com/WebAssembly/binaryen/tree/version_116), assemble `pairs.wat`

```wat
(module
  (type $pair (struct (field $fst f64) (field $snd f64)))
  (func (export "cons") (param $a f64) (param $b f64) (result (ref $pair))
    (struct.new $pair
      (local.get $a)
      (local.get $b)))
  (func (export "sub") (param $ab (ref $pair)) (result f64)
    (f64.sub
      (struct.get $pair $fst
        (local.get $ab))
      (struct.get $pair $snd
        (local.get $ab)))))
```

via this command:

```sh
wasm-as --enable-reference-types --enable-gc pairs.wat
```

Then download the Node nightlies from Jan 4 and Jan 5:

- https://nodejs.org/download/nightly/v22.0.0-nightly20240104084d761dfc/
- https://nodejs.org/download/nightly/v22.0.0-nightly2024010568c8472ed9/

And with each of those nightlies, try to run `pairs.js`

```js
import * as fs from "fs/promises";

const bytes = await fs.readFile("pairs.wasm");
const mod = await WebAssembly.compile(bytes);
const { cons, sub } = (await WebAssembly.instantiate(mod)).exports;
const pair = cons(5, 3);
console.log(sub(pair));
```

via this command:

```sh
node --experimental-wasm-gc pairs.js
```

The Jan 5 nightly prints `2` to the console as expected, while the Jan 4 nightly instead gives this error message:

```
node:internal/process/esm_loader:34
      internalBinding('errors').triggerUncaughtException(
                                ^

[CompileError: WebAssembly.compile(): invalid value type 'stringref', enable with --experimental-wasm-stringref @+22]

Node.js v22.0.0-nightly20240104084d761dfc
```