### PR TITLE
Update Safari support for multi-value

### DIFF
--- a/features.json
+++ b/features.json
@@ -147,7 +147,7 @@
 				"bigInt": ["15", "wasm-bigint is supported in desktop Safari since 14.1 and iOS Safari since 14.5; however BigInt64Array, which is needed by Emscripten, was released in 15"],
 				"bulkMemory": "15",
 				"exceptions": "15.2",
-				"multiValue": true,
+				"multiValue": "13.1",
 				"mutableGlobals": "12",
 				"referenceTypes": "15",
 				"saturatedFloatToInt": "15",


### PR DESCRIPTION
https://github.com/WebKit/WebKit/commit/fbf101220cf95a9973131d63f20b8e4507dff638 is tagged with "Safari-609.1.11.2" which https://github.com/mdn/browser-compat-data/blob/main/browsers/safari.json suggests corresponds to Safari 13.1