### PR TITLE
Add extended-const to Safari

### DIFF
--- a/features.json
+++ b/features.json
@@ -147,6 +147,7 @@
 				"bigInt": ["15", "wasm-bigint is supported in desktop Safari since 14.1 and iOS Safari since 14.5; however BigInt64Array, which is needed by Emscripten, was released in 15"],
 				"bulkMemory": "15",
 				"exceptions": "15.2",
+				"extendedConst": ["flag", "Enabled in Safari Technology Preview 184"],
 				"multiValue": "13.1",
 				"mutableGlobals": "12",
 				"referenceTypes": "15",


### PR DESCRIPTION
Enabled in STP 184: https://webkit.org/blog/14780/release-notes-for-safari-technology-preview-184/