### PR TITLE
Remove the Wasm 1.0 banner

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -24,18 +24,6 @@
     </nav>
     </div>
   </header>
-  <section class="banner-update">
-    <div class="container-narrow">
-      <div class="banner-update-icon"></div>
-      <span class="banner-update-date"></span>
-      <span>WebAssembly 1.0 has shipped in 4 major browser engines.
-        &nbsp;<img width="48" height="48" src="/images/firefox.svg" alt="Firefox"/>
-        &nbsp;<img width="48" height="48" src="/images/chrome.svg" alt="Chrome"/>
-        &nbsp;<img width="48" height="48" src="/images/safari.svg" alt="Safari"/>
-        &nbsp;<img width="48" height="48" src="/images/edge.svg" alt="Edge"/>
-        &nbsp;&#8203;<a href="/features/">Learn&nbsp;more</a></span>
-    </div>
-  </section>
   {% if page.lead %}
   <section class="page-section-spacious flush-bottom">
     <div class="container-narrow">


### PR DESCRIPTION
Per some CG meeting discussion :)

(This PR is a bit cheeky, and it may be better to instead update the contents of the banner to reflect what is currently shipped.)