### PR TITLE
Begin tracking JSPI support for Firefox

### DIFF
--- a/features.json
+++ b/features.json
@@ -126,6 +126,7 @@
 				"exceptions": "100",
 				"extendedConst": "112",
 				"gc": "120",
+				"jspi": ["flag", "Enabled in Nightly, unavailable in Beta/Release"],
 				"memory64": ["flag", "Enabled in Nightly, unavailable in Beta/Release"],
 				"multiMemory": "125",
 				"multiValue": "78",

--- a/features.json
+++ b/features.json
@@ -126,7 +126,7 @@
 				"exceptions": "100",
 				"extendedConst": "112",
 				"gc": "120",
-				"jspi": ["flag", "Enabled in Nightly, unavailable in Beta/Release"],
+				"jspi": ["flag", "Requires flag `javascript.options.wasm_js_promise_integration` in Nightly, unavailable in Beta/Release"],
 				"memory64": ["flag", "Enabled in Nightly, unavailable in Beta/Release"],
 				"multiMemory": "125",
 				"multiValue": "78",


### PR DESCRIPTION
This begins tracking JSPI support on Firefox, which has been merged as part of Firefox 127 (nightly). Implementation work is still ongoing, but a minimal version appears to be working already. I don't think it's stable yet, but I think it should be available for testing behind a flag?

@yurydelendik as the implementer of this in Firefox, can I ask you to review the diff here? Ty!

## References
- [Firefox spec position (positive)](https://mozilla.github.io/standards-positions/#wasm-js-promise-integration)
- [Bugzilla bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1897981)
