### PR TITLE
`tail-calls` for `wasmtime`

### DIFF
--- a/features.json
+++ b/features.json
@@ -174,7 +174,7 @@
 				"saturatedFloatToInt": true,
 				"signExtensions": true,
 				"simd": "0.33",
-				"tailCall": ["flag", "Requires flag `--wasm=tail-call`"],
+				"tailCall": ["22", "Enabled by default when using the Cranelift backend, except for the s390x architecture"],
 				"threads": "15"
 			}
 		},


### PR DESCRIPTION
Apparently the situation is a little bit complicated. The feature is enabled since [Version 21](https://github.com/bytecodealliance/wasmtime/blob/release-21.0.0/RELEASES.md#added), but only for the Cranelift backend, except for the s390x architecture.

However, the feature was accidentally not active until [Version 22](https://github.com/bytecodealliance/wasmtime/pull/8682).

Also wasmtime 22 isn't out yet (should come out June 17th).