### PR TITLE
Move exception handling to phase 4

### DIFF
--- a/features.json
+++ b/features.json
@@ -19,7 +19,7 @@
 		"exceptions": {
 			"description": "Exception handling",
 			"url": "https://github.com/WebAssembly/exception-handling/blob/master/proposals/exception-handling/Exceptions.md",
-			"phase": 3
+			"phase": 4
 		},
 		"extendedConst": {
 			"description": "Extended constant expressions",


### PR DESCRIPTION
Exception handling has been voted to move to phase 4 ([ref](https://x.com/TitzerBL/status/1813253694819037321)). This patch reflects that change in the feature tracker on the website. Thanks!