### PR TITLE
Wasmtime has implemented and enabled-by-default the extended-const proposal in version 25

### DIFF
--- a/features.json
+++ b/features.json
@@ -231,6 +231,7 @@
 				"customAnnotationSyntaxInTheTextFormat": true,
 				"customPageSizes": ["flag", "Requires flag `--wasm=custom-page-sizes`"],
 				"esmIntegration": null,
+				"extendedConst": "25",
 				"gc": ["flag", "Requires flag `--wasm=gc`"],
 				"jspi": null,
 				"jsStringBuiltins": null,


### PR DESCRIPTION
@dschuff PTAL, thanks!