### PR TITLE
Update link for GraalWasm.

### DIFF
--- a/features.json
+++ b/features.json
@@ -285,7 +285,7 @@
 			}
 		},
 		"GraalWasm": {
-			"url": "https://github.com/oracle/graal/tree/master/wasm",
+			"url": "https://www.graalvm.org/webassembly/",
 			"logo": "/images/graalvm.svg",
 			"features": {
 				"bigInt": "21.3",


### PR DESCRIPTION
This is following up on https://github.com/WebAssembly/website/pull/396.

The new GraalWasm landing page is now available at https://www.graalvm.org/webassembly/.