### PR TITLE
Add Haskell link to developers-guide.md

### DIFF
--- a/getting-started/developers-guide.md
+++ b/getting-started/developers-guide.md
@@ -23,6 +23,7 @@ layout: getting-started
   - [Pascal](https://wiki.freepascal.org/WebAssembly/Compiler)
   - [Zig](https://ziglang.org/documentation/master/#WebAssembly)
   - [Grain](https://grain-lang.org/docs/)
+  - [Haskell](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/wasm.html)
   - Python (via [Pyodide](https://pyodide.org/en/stable/) or [Nuitka (py2wasm)](https://github.com/wasmerio/py2wasm))
 - Use the compiled WebAssembly...
   - [from JavaScript code](https://developer.mozilla.org/en-US/docs/WebAssembly/Loading_and_running)


### PR DESCRIPTION
This PR adds a link to the Haskell-WASM documentation in the Developer Guide section of the WebAssembly website. The addition provides an important resource for developers who may be interested in learning more about using Haskell with WebAssembly.

@tomayac 