### PR TITLE
Update feature flag for stack switching proposal

### DIFF
--- a/features.json
+++ b/features.json
@@ -195,7 +195,7 @@
         "simd": "91",
         "stackSwitching": [
           "flag",
-          "Requires CLI flag `--js-flags=--experimental-wasm-stack-switching`"
+          "Requires CLI flag `--js-flags=--experimental-wasm-wasmfx`"
         ],
         "tailCall": "112",
         "threads": "74",
@@ -335,7 +335,7 @@
         "simd": "16.4",
         "stackSwitching": [
           "flag",
-          "Requires flag `--experimental-wasm-stack-switching`"
+          "Requires flag `--experimental-wasm-wasmfx`"
         ],
         "tailCall": "20.0",
         "threads": "16.4",
@@ -389,7 +389,7 @@
         "simd": "1.9",
         "stackSwitching": [
           "flag",
-          "Requires flag `--v8-flags=--experimental-wasm-stack-switching`"
+          "Requires flag `--v8-flags=--experimental-wasm-wasmfx`"
         ],
         "tailCall": "1.32",
         "threads": "1.9",


### PR DESCRIPTION
It seems that the v8 flag listed on https://webassembly.org/roadmap for the stack switching proposal is incorrect; the `--experimental-wasm-stack-switching` flag exists, but it [seems to be unused](https://github.com/search?q=repo%3Av8%2Fv8+path%3Asrc%2Fwasm+stack_switching&type=code) (note that all references to stack_switching flags are different v8 flags relating to jspi [I think]). However, the `--experimental-wasm-wasmfx` flag [has been added recently](https://chromium-review.googlesource.com/c/v8/v8/+/6158267), with an incomplete implementation (not yet landed in stable chrome as far as I can tell).

#400 says that there was an in-progress implementation of stack switching back in September, but as far as I can tell this isn't correct?

This pull request updates the listed feature flags for the stack switching proposal... it's difficult to test these because the change was made recently enough to not be in stable releases yet, but hopefully it's correct now. (And hopefully I haven't completely misunderstood the whole situation.)