### PR TITLE
Rename "Feature Extensions" to "Feature Status"

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -35,7 +35,7 @@
           >
           <a class="site-nav-item btn" href="/specs">Specs</a>
           <a class="site-nav-item btn" href="/docs/faq/">Docs</a>
-          <a class="site-nav-item btn" href="/features/">Feature Extensions</a>
+          <a class="site-nav-item btn" href="/features/">Feature Status</a>
           <a class="site-nav-item btn" href="/community/resources/"
             >Community</a
           >

--- a/features.md
+++ b/features.md
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-# Feature Extensions
+# Feature Status
 
 In November 2017, WebAssembly CG members representing four browsers, Chrome,
 Edge, Firefox, and WebKit, reached consensus that the design of the initial


### PR DESCRIPTION
\#361 renamed this page from "Future features" to "Feature Extensions', as many of these features are standardized and widely implemented today. Looking at it now, the word "extensions" may also be misleading, as it may be read as suggesting that the MVP remains the base language, with all other features being held separate, as discrete extras.

In practice, when features are added to the spec, they are integrated and not kept separate. They appear as indistinguishable from the features that were in the MVP.

Consequently, I propose this page be titled "Feature Status", as it documents the implementation status of various features.