### PR TITLE
Add "from Java code" link.

### DIFF
--- a/getting-started/developers-guide.md
+++ b/getting-started/developers-guide.md
@@ -51,6 +51,7 @@ layout: getting-started
 - [from JavaScript code](https://developer.mozilla.org/en-US/docs/WebAssembly/Loading_and_running)
 - [as a CLI application](https://github.com/bytecodealliance/wasmtime/blob/master/docs/WASI-tutorial.md)
 - [from Node.js (with access to system resources)](https://nodejs.org/api/wasi.html)
+- [from Java code](https://www.graalvm.org/webassembly/)
 
 ## Inspect WebAssembly…
 


### PR DESCRIPTION
The [GraalWasm landing page](https://www.graalvm.org/webassembly/) includes a simple getting started and references demos and guides that illustrate, for example, how to [embed Wasm in a Spring Boot application](https://github.com/graalvm/graal-languages-demos/blob/main/graalwasm/graalwasm-spring-boot-photon/).