### PR TITLE
Update Deno features

### DIFF
--- a/features.json
+++ b/features.json
@@ -344,6 +344,7 @@
           "Requires flag `--v8-flags=--experimental-wasm-compilation-hints`"
         ],
         "customAnnotationSyntaxInTheTextFormat": null,
+        "esmIntegration": "2.1",
         "exceptionsFinal": "2.3.2",
         "exceptions": "1.16",
         "extendedConst": "1.33",


### PR DESCRIPTION
From Deno v2.3.2, the V8 version has been updated, enabling more features.
https://github.com/denoland/deno/issues/30025

[ESM Integration is supported from v2.1](https://deno.com/blog/v2.1#first-class-wasm-support), and Memory64 seems to be supported from v2.2 based on my own tests.