### PR TITLE
Update Safari version for mutable globals

### DIFF
--- a/features.json
+++ b/features.json
@@ -257,7 +257,7 @@
         "extendedConst": "17.4",
         "gc": "18.2",
         "multiValue": "13.1",
-        "mutableGlobals": "12",
+        "mutableGlobals": "13.1",
         "referenceTypes": "15",
         "relaxedSimd": [
           "flag",


### PR DESCRIPTION
Implemented via https://github.com/WebKit/WebKit/commit/3a60ed81db08242709d161f2dce472aa228f86c9 in Safari 13.1.

See also: https://github.com/mdn/browser-compat-data/pull/27201