### PR TITLE
Add custom element to Andreas' article

### DIFF
--- a/_posts/2025-09-17-wasm-3.0.md
+++ b/_posts/2025-09-17-wasm-3.0.md
@@ -9,7 +9,7 @@ _Published on September 17, 2025 by [Andreas Rossberg](https://github.com/rossbe
 
 Three years ago, [version 2.0](https://webassembly.org/news/2025-03-20-wasm-2.0/) of the Wasm standard was (essentially) finished, which brought a number of new features, such as vector instructions, bulk memory operations, multiple return values, and simple reference types.
 
-In the meantime, the Wasm W3C Community Group and Working Group have not been lazy. Today, we are happy to announce the release of Wasm 3.0 as the new “live” standard.
+In the meantime, the Wasm W3C Community Group and Working Group have not been lazy. Today, we are happy to announce the release of [Wasm 3.0](https://webassembly.github.io/spec/core/) as the new “live” standard.
 
 ![Title page of the WebAssembly Specification, Release 3.0, 2025-09-17](/assets/wasm3_0.png)
 

--- a/_posts/2025-09-17-wasm-3.0.md
+++ b/_posts/2025-09-17-wasm-3.0.md
@@ -17,25 +17,45 @@ This is a substantially larger update: several big features, some of which have 
 
 * [*64-bit address space.*](https://github.com/WebAssembly/spec/blob/wasm-3.0/proposals/memory64/Overview.md) Memories and tables can now be declared to use `i64` as their address type instead of just `i32`. That expands the available address space of Wasm applications from 4 gigabytes to (theoretically) 16 exabytes, to the extent that physical hardware allows. While the web will necessarily keep enforcing certain limits — on the web, a 64-bit memory is limited to 16 gigabytes — the new flexibility is especially interesting for non-web ecosystems using Wasm, as they can support much, much larger applications and data sets now.
 
+<wasm-compat wasm-feature="memory64"></wasm-compat>
+
 * [*Multiple memories.*](https://github.com/WebAssembly/spec/blob/wasm-3.0/proposals/multi-memory/Overview.md) Contrary to popular belief, Wasm applications were always able to use multiple memory objects — and hence multiple address spaces — simultaneously. However, previously that was only possible by declaring and accessing each of them in separate modules. This gap has been closed, a single module can now declare (define or import) multiple memories and directly access them, including directly copying data between them. This finally allows tools like wasm-merge, which perform “static linking” on two or more Wasm modules by merging them into one, to work for _all_ Wasm modules. It also paves the way for new uses of separate address spaces, e.g., for security (separating private data), for buffering, or for instrumentation.
+
+<wasm-compat wasm-feature="multiMemory"></wasm-compat>
 
 * [*Garbage collection.*](https://github.com/WebAssembly/spec/blob/wasm-3.0/proposals/gc/Overview.md) In addition to expanding the capabilities of raw linear memories, Wasm also adds support for a new (and separate) form of storage that is automatically managed by the Wasm runtime via a garbage collector. Staying true to the spirit of Wasm as a low-level language, Wasm GC is low-level as well: a compiler targeting Wasm can declare the memory layout of its runtime data structures in terms of struct and array types, plus unboxed tagged integers, whose allocation and lifetime is then handled by Wasm. But that’s it. Everything else, such as engineering suitable representations for source-language values, including implementation details like method tables, remains the responsibility of compilers targeting Wasm. There are no built-in object systems, nor closures or other higher-level constructs — which would inevitably be heavily biased towards specific languages. Instead, Wasm only provides the basic building blocks for representing such constructs and focuses purely on the memory management aspect.
 
+<wasm-compat wasm-feature="gc"></wasm-compat>
+
 * [*Typed references.*](https://github.com/WebAssembly/spec/blob/wasm-3.0/proposals/function-references/Overview.md) The GC extension is built upon a substantial extension to the Wasm type system, which now supports much richer forms of references. Reference types can now describe the exact shape of the referenced heap value, avoiding additional runtime checks that would otherwise be needed to ensure safety. This more expressive typing mechanism, including subtyping and type recursion, is also available for function references, making it possible to perform safe indirect function calls without any runtime type or bounds check, through the new `call_ref` instruction.
+
+<wasm-compat wasm-feature="typedFunctionReferences"></wasm-compat>
 
 * [*Tail calls.*](https://github.com/WebAssembly/spec/blob/wasm-3.0/proposals/tail-call/Overview.md) Tail calls are a variant of function calls that immediately exit the current function, and thereby avoid taking up additional stack space. Tail calls are an important mechanism that is used in various language implementations both in user-visible ways (e.g., in functional languages) and for internal techniques (e.g., to implement stubs). Wasm tail calls are fully general and work for callees both selected statically (by function index) and dynamically (by reference or table).
 
+<wasm-compat wasm-feature="tailCall"></wasm-compat>
+
 * [*Exception handling.*](https://github.com/WebAssembly/spec/blob/wasm-3.0/proposals/exception-handling/Exceptions.md) Exceptions provide a way to locally abort execution, and are a common feature in modern programming languages. Previously, there was no efficient way to compile exception handling to Wasm, and existing compilers typically resorted to convoluted ways of implementing them by escaping to the host language, e.g., JavaScript. This was neither portable nor efficient. Wasm 3.0 hence provides native exception handling within Wasm. Exceptions are defined by declaring exception tags with associated payload data. As one would expect, an exception can be thrown, and selectively be caught by a surrounding handler, based on its tag. Exception handlers are a new form of block instruction that includes a dispatch list of tag/label pairs or catch-all labels to define where to jump when an exception occurs.
+
+<wasm-compat wasm-feature="exceptionsFinal"></wasm-compat>
 
 * [*Relaxed vector instructions.*](https://github.com/WebAssembly/spec/blob/wasm-3.0/proposals/relaxed-simd/Overview.md) Wasm 2.0 added a large set of vector (SIMD) instructions, but due to differences in hardware, some of these instructions have to do extra work on some platforms to achieve the specified semantics. In order to squeeze out maximum performance, Wasm 3.0 introduces “relaxed” variants of these instructions that are allowed to have implementation-dependent behavior in certain edge cases. This behavior must be selected from a pre-specified set of legal choices.
 
+<wasm-compat wasm-feature="relaxedSimd"></wasm-compat>
+
 * [*Deterministic profile.*](https://github.com/WebAssembly/profiles/blob/main/proposals/profiles/Overview.md) To make up for the added semantic fuzziness of relaxed vector instructions, and in order to support settings that demand or need deterministic execution semantics (such as blockchains, or replayable systems), the Wasm standard now specifies a deterministic default behavior for every instruction with otherwise non-deterministic results — currently, this includes floating-point operators and their generated NaN values and the aforementioned relaxed vector instructions. Between platforms choosing to implement this deterministic execution profile, Wasm thereby is fully deterministic, reproducible, and portable.
 
+<wasm-compat wasm-feature="profiles"></wasm-compat>
+
 * [*Custom annotation syntax.*](https://github.com/WebAssembly/spec/blob/wasm-3.0/proposals/annotations/Overview.md) Finally, the Wasm text format has been enriched with generic syntax for placing annotations in Wasm source code. Analogous to custom sections in the binary format, these annotations are not assigned any meaning by the Wasm standard itself, and can be chosen to be ignored by implementations. However, they provide a way to represent the information stored in custom sections in human-readable and writable form, and concrete annotations can be specified by downstream standards.
+
+<wasm-compat wasm-feature="customAnnotationSyntaxInTheTextFormat"></wasm-compat>
 
 In addition to these core features, embeddings of Wasm into JavaScript benefit from a new extension to the JS API:
 
 * [*JS string builtins.*](https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md) JavaScript string values can already be passed to Wasm as externrefs. Functions from this new primitive library can be imported into a Wasm module to directly access and manipulate such external string values inside Wasm.
+
+<wasm-compat wasm-feature="jsStringBuiltins"></wasm-compat>
 
 With these new features, Wasm has much better support for compiling high-level programming languages. Enabled by this, we have seen various new languages popping up to target Wasm, such as [Java](https://github.com/google/j2cl/blob/master/docs/getting-started-j2wasm.md), [OCaml](https://dune.readthedocs.io/en/stable/wasmoo.html), [Scala](https://www.scala-js.org/doc/project/webassembly.html), [Kotlin](https://kotlinlang.org/docs/wasm-overview.html), [Scheme](https://spritely.institute/hoot/), or [Dart](https://dart.dev/web/wasm), all of which use the new GC feature.
 

--- a/features.json
+++ b/features.json
@@ -96,6 +96,11 @@
       "url": "https://github.com/WebAssembly/mutable-global/blob/master/proposals/mutable-global/Overview.md",
       "phase": 5
     },
+    "profiles": {
+      "description": "Language Profiles for Wasm",
+      "url": "https://github.com/WebAssembly/profiles/blob/main/proposals/profiles/Overview.md",
+      "phase": 1
+    },
     "referenceTypes": {
       "description": "Reference Types",
       "url": "https://github.com/WebAssembly/reference-types/blob/master/proposals/reference-types/Overview.md",


### PR DESCRIPTION
Hey Andreas,

I got nerd-sniped and actually implemented the [`<wasm-compat>` custom element](https://webassembly.org/news/2025-09-17-wasm-compat/) I was talking about in https://github.com/WebAssembly/website/pull/466#pullrequestreview-3233563473. This PR adds the custom element to each of the features mentioned in [your article](https://webassembly.org/news/2025-09-17-wasm-3.0/). This is how it looks like:

<img width="551" height="866" alt="Screenshot 2025-09-18 at 11 14 38" src="https://github.com/user-attachments/assets/b418b8f2-b6f9-442a-9623-17fea5b59e20" />
 
What do you think? I personally really like it, but since it's your article, I'd better ask first `:-)`. No hard feelings if you don't like it, just to be sure…

PS: Not sure if you saw it, but you're currently number 3 on Hacker News:

<img width="578" height="149" alt="Screenshot 2025-09-18 at 11 20 18" src="https://github.com/user-attachments/assets/e16754fa-5f0a-44e0-82ae-8b47a0e4fb79" />
