### PR TITLE
features: update list of phase 2 proposals

### DIFF
--- a/features.json
+++ b/features.json
@@ -26,6 +26,11 @@
       "url": "https://github.com/WebAssembly/annotations/blob/main/proposals/annotations/Overview.md",
       "phase": 5
     },
+    "customDescriptors": {
+      "description": "Custom Descriptors and JS Interop",
+      "url": "https://github.com/WebAssembly/custom-descriptors/blob/main/proposals/custom-descriptors/Overview.md",
+      "phase": 2
+    },
     "customPageSizes": {
       "description": "Custom Page Sizes",
       "url": "https://github.com/WebAssembly/custom-page-sizes/blob/main/proposals/custom-page-sizes/Overview.md",
@@ -51,6 +56,11 @@
       "url": "https://github.com/WebAssembly/extended-const/blob/master/proposals/extended-const/Overview.md",
       "phase": 5
     },
+    "extendedNameSection": {
+      "description": "Extended Name Section",
+      "url": "https://github.com/WebAssembly/extended-name-section/blob/main/proposals/extended-name-section/Overview.md",
+      "phase": 2
+    },
     "gc": {
       "description": "Garbage Collection",
       "url": "https://github.com/WebAssembly/gc",
@@ -65,6 +75,11 @@
       "description": "JS Promise Integration",
       "url": "https://github.com/WebAssembly/js-promise-integration",
       "phase": 4
+    },
+    "jsPrimitiveBuiltins": {
+      "description": "JS Primitive Builtins",
+      "url": "https://github.com/WebAssembly/js-primitive-builtins/blob/main/proposals/js-primitive-builtins/Overview.md",
+      "phase": 2
     },
     "jsStringBuiltins": {
       "description": "JS String Builtins",
@@ -96,6 +111,11 @@
       "url": "https://github.com/WebAssembly/mutable-global/blob/master/proposals/mutable-global/Overview.md",
       "phase": 5
     },
+    "numericValuesInWat": {
+      "description": "Numeric Values in WAT Data Segments",
+      "url": "https://github.com/WebAssembly/wat-numeric-values/blob/main/proposals/wat-numeric-values/Overview.md",
+      "phase": 2
+    },
     "profiles": {
       "description": "Language Profiles for Wasm",
       "url": "https://github.com/WebAssembly/profiles/blob/main/proposals/profiles/Overview.md",
@@ -106,10 +126,20 @@
       "url": "https://github.com/WebAssembly/reference-types/blob/master/proposals/reference-types/Overview.md",
       "phase": 5
     },
+    "relaxedDeadCodeValidation": {
+      "description": "Relaxed dead code validation",
+      "url": "https://github.com/WebAssembly/relaxed-dead-code-validation/blob/main/proposals/relaxed-dead-code-validation/Overview.md",
+      "phase": 2
+    },
     "relaxedSimd": {
       "description": "Relaxed SIMD",
       "url": "https://github.com/WebAssembly/relaxed-simd/tree/main/proposals/relaxed-simd",
       "phase": 5
+    },
+    "roundingVariants": {
+      "description": "Rounding Variants",
+      "url": "https://github.com/WebAssembly/rounding-mode-control/blob/main/proposals/rounding-mode-control/Overview.md",
+      "phase": 2
     },
     "saturatedFloatToInt": {
       "description": "Non-trapping float-to-int Conversions",


### PR DESCRIPTION
- Add phase 2 proposals:
  * everything listed as phase 2 on https://webassembly.org/features/
  * JS Primitive Builtins which was moved to phase 2 today.

_Instrument and Tracing Technologies_ remains in phase 2 in this PR, even though it's been marked inactive. I can address that in a follow-up PR.