### PR TITLE
Mark Relaxed SIMD as supported on GraalWasm.

### DIFF
--- a/features.json
+++ b/features.json
@@ -478,6 +478,7 @@
         "multiValue": "22.3",
         "mutableGlobals": "21.3",
         "referenceTypes": "23.0",
+        "relaxedSimd": ["flag", "Requires flag `--wasm.RelaxedSIMD=true`"],
         "saturatedFloatToInt": "22.3",
         "signExtensions": "22.3",
         "simd": "24.1",


### PR DESCRIPTION
GraalWasm supports the Relaxed SIMD proposal when using the `--wasm.RelaxedSIMD` flag.

https://github.com/oracle/graal/blob/master/wasm/CHANGELOG.md#version-2420