### PR TITLE
Update link to WASI Proposals.md

### DIFF
--- a/specs.md
+++ b/specs.md
@@ -20,7 +20,7 @@ layout: default
     extensions to the JavaScript API made available specifically in web
     browsers, in particular, an interface for streaming compilation and
     instantiation from origin-bound `Response` types.
-  - [WASI API](https://github.com/WebAssembly/WASI/blob/main/Proposals.md):
+  - [WASI API](https://github.com/WebAssembly/WASI/blob/main/docs/Proposals.md):
     defines a modular system interface to run WebAssembly outside the web,
     providing access to things like files, network connections, clocks, and
     random numbers.


### PR DESCRIPTION
The location of the WASI Proposals.md file is being changed in https://github.com/WebAssembly/WASI/pull/831, this updates all the links in this repository to reflect that change. I'm initially filing this PR as a draft. I'll mark it as ready to review once the linked PR has been merged. Thanks!