### PR TITLE
Safari v26.2 Supports JS String Builtins

### DIFF
--- a/features.json
+++ b/features.json
@@ -353,6 +353,7 @@
         "exceptions": "15.2",
         "extendedConst": "17.4",
         "gc": "18.2",
+        "jsStringBuiltins": "26.2",
         "multiValue": "13.1",
         "mutableGlobals": "13.1",
         "profiles": null,


### PR DESCRIPTION
The latest Safari v26.2 now supports JS string builtins.

- [Safari Blog Post](https://webkit.org/blog/17640/webkit-features-for-safari-26-2/#webassembly)
- [Caniuse](https://caniuse.com/mdn-webassembly_jsstringbuiltins)
- [WPT](https://wpt.fyi/results/wasm/jsapi/js-string?label=master&label=stable&product=safari-26.1%20%2821622.2.11.11.9%29&product=safari-26.2%20%2821623.1.14.11.9%29&aligned&q=string)