### PR TITLE
Update Wasmtime's memory64 support

### DIFF
--- a/features.json
+++ b/features.json
@@ -535,7 +535,7 @@
         "gc": ["flag", "Requires flag `--wasm=gc`"],
         "jspi": null,
         "jsStringBuiltins": null,
-        "memory64": ["flag", "Requires flag `--wasm=memory64`"],
+        "memory64": "30",
         "multiMemory": "15",
         "multiValue": "0.17",
         "mutableGlobals": true,


### PR DESCRIPTION
The memory64 proposal has been enabled by default in Wasmtime (not behind a flag) since version 30 which was released February 20, 2025.

https://github.com/bytecodealliance/wasmtime/releases/tag/v30.0.0