### PR TITLE
Update Wasmtime's support for branch hinting

### DIFF
--- a/features.json
+++ b/features.json
@@ -547,6 +547,7 @@
       "category": "Standalone Runtimes",
       "features": {
         "bigInt": null,
+        "branchHinting": ["flag", "Requires flag `--wasm=branch-hinting`"],
         "bulkMemory": "0.20",
         "customAnnotationSyntaxInTheTextFormat": true,
         "customPageSizes": ["flag", "Requires flag `--wasm=custom-page-sizes`"],


### PR DESCRIPTION
Enabled behind a flag: https://github.com/bytecodealliance/wasmtime/releases/tag/v46.0.0