### PR TITLE
Update supported version for Node jspi and exnref eh

### DIFF
--- a/features.json
+++ b/features.json
@@ -411,7 +411,7 @@
           "Requires flag `--experimental-wasm-compilation-hints`"
         ],
         "customAnnotationSyntaxInTheTextFormat": null,
-        "exceptionsFinal": "25.0",
+        "exceptionsFinal": "24.15",
         "exceptions": "17.0",
         "extendedConst": "21.0",
         "gc": "22.0",
@@ -419,7 +419,7 @@
           "flag",
           "Requires flag `--experimental-wasm-instruction-tracing`"
         ],
-        "jspi": ["flag", "Requires flag `--experimental-wasm-jspi`"],
+        "jspi":"26.0",
         "jsStringBuiltins": [
           "flag",
           "Requires flag `--experimental-wasm-imported-strings`"


### PR DESCRIPTION
exnref eh was backported here:
https://github.com/nodejs/node/pull/62567

jspi doesn't require a flag from 26.0