### PR TITLE
Wide Arithmetic is now in Phase 4

### DIFF
--- a/features.json
+++ b/features.json
@@ -254,7 +254,7 @@
     "wideArithmetic": {
       "description": "Wide Arithmetic",
       "url": "https://github.com/WebAssembly/wide-arithmetic/blob/main/proposals/wide-arithmetic/Overview.md",
-      "phase": 3
+      "phase": 4
     }
   },
   "categories": [
@@ -312,7 +312,11 @@
           "flag",
           "Requires flag `chrome://flags/#enable-experimental-webassembly-features`"
         ],
-        "webContentSecurityPolicy": "97"
+        "webContentSecurityPolicy": "97",
+        "wideArithmetic": [
+          "flag",
+          "Requires CLI flag `--js-flags=--wasm-wide-arithmetic`"
+        ]
       }
     },
     "Firefox": {
@@ -353,7 +357,11 @@
           "flag",
           "Enabled in Nightly, requires flag `--enable-wasm-type-reflections` in Beta/Release"
         ],
-        "webContentSecurityPolicy": "102"
+        "webContentSecurityPolicy": "102",
+        "wideArithmetic": [
+          "flag",
+          "Enabled in Nightly, requires flag `javascript.options.wasm_wide_arithmetic` in Beta/Release"
+        ]
       }
     },
     "Safari": {
@@ -401,7 +409,11 @@
           "flag",
           "Supported in Safari 18.2, only supports `WebAssembly.Module.imports` and `WebAssembly.Module.exports`"
         ],
-        "webContentSecurityPolicy": "16"
+        "webContentSecurityPolicy": "16",
+        "wideArithmetic": [
+          "flag",
+          "Requires JavaScriptCore flag `useWasmWideArithmetic`"
+        ]
       }
     },
     "Node.js": {
@@ -449,7 +461,11 @@
           "flag",
           "Requires flag `--experimental-wasm-type-reflection`"
         ],
-        "webContentSecurityPolicy": null
+        "webContentSecurityPolicy": null,
+        "wideArithmetic": [
+          "flag",
+          "Requires flag `--wasm-wide-arithmetic`"
+        ]
       }
     },
     "Deno": {
@@ -492,7 +508,11 @@
           "flag",
           "Requires flag `--v8-flags=--experimental-wasm-type-reflection`"
         ],
-        "webContentSecurityPolicy": null
+        "webContentSecurityPolicy": null,
+        "wideArithmetic": [
+          "flag",
+          "Requires flag `--v8-flags=--wasm-wide-arithmetic`"
+        ]
       }
     },
     "GraalWasm": {


### PR DESCRIPTION
This additionally documents the feature gates used by Chrome, Firefox, Safari, Node.js and Deno.

Sources:

- [Phase 4 vote at the August 2026 CG meeting](https://github.com/WebAssembly/meetings/blob/main/main/2026/CG-2026-08.md#wednesday-august-5)

- Chrome, Node.js and Deno: [V8 feature gate definition](https://chromium.googlesource.com/v8/v8/+/HEAD/src/wasm/wasm-feature-flags.h)

- Firefox: [preference definition](https://searchfox.org/firefox-main/source/modules/libpref/init/StaticPrefList.yaml) and [implementation bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1949081)

- Safari: [JavaScriptCore option definition](https://github.com/WebKit/WebKit/blob/main/Source/JavaScriptCore/runtime/OptionsList.h) and [implementation commit](https://commits.webkit.org/311366@main)