### PR TITLE
features.json: watr supports half precision as of 5.8.0

### DIFF
--- a/features.json
+++ b/features.json
@@ -927,6 +927,7 @@
         "extendedConst": true,
         "extendedNameSection": null,
         "gc": true,
+        "halfPrecision": "5.8.0",
         "jsPrimitiveBuiltins": null,
         "jsStringBuiltins": true,
         "jspi": null,


### PR DESCRIPTION
Marks [half precision](https://github.com/WebAssembly/half-precision) as supported by watr since [v5.8.0](https://www.npmjs.com/package/watr/v/5.8.0).

Covers the full instruction set from the proposal Overview: `f32.load_f16`/`f32.store_f16`, all `f16x8.*` lane/arithmetic/comparison/conversion ops, `f16x8.madd`/`nmadd`, and `(v128.const f16x8 ...)` with exact round-to-nearest-even binary16 literal encoding. Opcodes follow V8 (`--experimental-wasm-fp16`); output is differentially tested against V8 validation, `Float16Array` arithmetic, and `DataView.setFloat16` in [test/half-precision.js](https://github.com/dy/watr/blob/main/test/half-precision.js).