### PR TITLE
features.json: watr supports acquire-release atomics as of 5.9.0

### DIFF
--- a/features.json
+++ b/features.json
@@ -945,6 +945,7 @@
       "logo": "/images/watr.svg",
       "category": "Tools",
       "features": {
+        "acquireReleaseAtomics": "5.9.0",
         "bigInt": true,
         "branchHinting": true,
         "bulkMemory": true,


### PR DESCRIPTION
Adds `"acquireReleaseAtomics": "5.9.0"` to the watr entry.

watr 5.9.0 ([npm](https://www.npmjs.com/package/watr/v/5.9.0)) compiles the ordering immediate on atomic loads, matching the proposal's reference interpreter scope: trailing `seqcst`/`acqrel` keyword in the text format, flags bit 4 plus ordering byte in the binary format. Byte output is verified against the official generated test ([test/core/acquire-release-atomics/basic.wast](https://github.com/WebAssembly/acquire-release-atomics/blob/main/test/core/acquire-release-atomics/basic.wast)), including the malformed case for non-atomic loads. Stores, RMW, fence and `pause` follow once the reference interpreter defines their text syntax.