### PR TITLE
Move Wasmi next to Wasm3 + update entries

### DIFF
--- a/features.json
+++ b/features.json
@@ -667,6 +667,39 @@
         "webContentSecurityPolicy": null
       }
     },
+    "Wasmi": {
+      "url": "https://github.com/wasmi-labs/wasmi/",
+      "logo": "/images/wasmi.png",
+      "category": "Standalone Runtimes",
+      "features": {
+        "bigInt": null,
+        "bulkMemory": "0.24",
+        "customAnnotationSyntaxInTheTextFormat": true,
+        "customPageSizes": "0.41",
+        "esmIntegration": null,
+        "exceptionsFinal": false,
+        "extendedConst": "0.29",
+        "gc": false,
+        "jspi": null,
+        "jsStringBuiltins": null,
+        "memory64": "0.41",
+        "multiMemory": "0.37",
+        "multiValue": "0.14",
+        "mutableGlobals": "0.14",
+        "profiles": "2.0.0",
+        "referenceTypes": "0.24",
+        "relaxedSimd": "0.44",
+        "saturatedFloatToInt": "0.14",
+        "signExtensions": "0.14",
+        "simd": "0.43",
+        "tailCall": "0.28",
+        "threads": null,
+        "typedFunctionReferences": false,
+        "typeReflection": null,
+        "webContentSecurityPolicy": null,
+        "wideArithmetic": "0.42"
+      }
+    },
     "wizard": {
       "url": "https://github.com/titzer/wizard-engine",
       "logo": "/images/wizard.svg",
@@ -1014,39 +1047,6 @@
         "typeReflection": null,
         "webContentSecurityPolicy": null,
         "wideArithmetic": true
-      }
-    },
-    "Wasmi": {
-      "url": "https://github.com/wasmi-labs/wasmi/",
-      "logo": "/images/wasmi.png",
-      "category": "Standalone Runtimes",
-      "features": {
-        "bigInt": null,
-        "bulkMemory": "0.24",
-        "customAnnotationSyntaxInTheTextFormat": true,
-        "customPageSizes": "0.41",
-        "esmIntegration": null,
-        "exceptionsFinal": null,
-        "extendedConst": "0.29",
-        "gc": null,
-        "jspi": null,
-        "jsStringBuiltins": null,
-        "memory64": "0.41",
-        "multiMemory": "0.37",
-        "multiValue": "0.14",
-        "mutableGlobals": "0.14",
-        "profiles": null,
-        "referenceTypes": "0.24",
-        "relaxedSimd": "0.44",
-        "saturatedFloatToInt": "0.14",
-        "signExtensions": "0.14",
-        "simd": "0.43",
-        "tailCall": "0.28",
-        "threads": null,
-        "typedFunctionReferences": null,
-        "typeReflection": null,
-        "webContentSecurityPolicy": null,
-        "wideArithmetic": "0.42"
       }
     },
     "Hexana": {


### PR DESCRIPTION
Reason: Wasmi and Wasm3 are friendly competitors and thus it is useful to readers of the website to have them be adjacent to each other for comparison.

## The Problem

Back when I added Wasmi to the list I politely appended it to the back.
However, I noticed that not all new additions do that.

The issue is that the last spots are inferior to the first due to the visualization of the table on the website.
Users have to scroll to see the last spots and therefore nobody wants to take those places.

This visualization worked until a certain threshold of entries existed.
How could we make this visualization fairer for now and future additions?

## Some Proposals

- Maybe adding more cathegories such as Web Runtime, JIT runtime, Interpreter runtime, Compilers, etc..?
    - Using tabs (that automatically cycle through) to switch between views so that nobody has to scroll for anything?
- Maybe a completely new visualization that no longer is a table?
- Maybe randomize the order each visit to the website?
